### PR TITLE
[Refactor/#120] 구독해지 후 구독하는 경우 고려하여 구독 API 수정

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
@@ -3,7 +3,10 @@ package com.few.api.repo.dao.subscription
 import com.few.api.repo.dao.subscription.command.InsertWorkbookSubscriptionCommand
 import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInAllSubscriptionCommand
 import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInWorkbookSubscriptionCommand
-import com.few.api.repo.dao.subscription.query.CountWorkbookSubscriptionQuery
+import com.few.api.repo.dao.subscription.query.SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt
+import com.few.api.repo.dao.subscription.record.WorkbookSubscriptionStatus
+import com.few.api.repo.dao.subscription.query.CountWorkbookMappedArticlesQuery
+import jooq.jooq_dsl.Tables.MAPPING_WORKBOOK_ARTICLE
 import jooq.jooq_dsl.Tables.SUBSCRIPTION
 import org.jooq.DSLContext
 import org.springframework.stereotype.Component
@@ -22,6 +25,14 @@ class SubscriptionDao(
             .fetchOne()
     }
 
+    fun reSubscribeWorkbookSubscription(command: InsertWorkbookSubscriptionCommand) {
+        dslContext.update(SUBSCRIPTION)
+            .set(SUBSCRIPTION.DELETED_AT, null as LocalDateTime?)
+            .where(SUBSCRIPTION.MEMBER_ID.eq(command.memberId))
+            .and(SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(command.workbookId))
+            .execute()
+    }
+
     fun updateDeletedAtInWorkbookSubscription(command: UpdateDeletedAtInWorkbookSubscriptionCommand) {
         dslContext.update(SUBSCRIPTION)
             .set(SUBSCRIPTION.DELETED_AT, LocalDateTime.now())
@@ -31,13 +42,16 @@ class SubscriptionDao(
             .execute()
     }
 
-    fun selectCountWorkbookSubscription(query: CountWorkbookSubscriptionQuery): Int {
-        return dslContext.selectCount()
+    fun selectAllWorkbookSubscriptionStatus(query: SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt): List<WorkbookSubscriptionStatus> {
+        return dslContext.select(
+            SUBSCRIPTION.ID.`as`(WorkbookSubscriptionStatus::id.name),
+            SUBSCRIPTION.DELETED_AT.isNotNull.`as`(WorkbookSubscriptionStatus::subHistory.name),
+            SUBSCRIPTION.PROGRESS.add(1).`as`(WorkbookSubscriptionStatus::day.name)
+        )
             .from(SUBSCRIPTION)
             .where(SUBSCRIPTION.MEMBER_ID.eq(query.memberId))
             .and(SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(query.workbookId))
-            .and(SUBSCRIPTION.DELETED_AT.isNull)
-            .fetchOne(0, Int::class.java) ?: 0
+            .fetchInto(WorkbookSubscriptionStatus::class.java)
     }
 
     fun updateDeletedAtInAllSubscription(command: UpdateDeletedAtInAllSubscriptionCommand) {
@@ -46,5 +60,12 @@ class SubscriptionDao(
             .set(SUBSCRIPTION.UNSUBS_OPINION, command.opinion) // TODO: opinion row 마다 중복 해결
             .where(SUBSCRIPTION.MEMBER_ID.eq(command.memberId))
             .execute()
+    }
+
+    fun countWorkbookMappedArticles(query: CountWorkbookMappedArticlesQuery): Int? {
+        return dslContext.selectCount()
+            .from(MAPPING_WORKBOOK_ARTICLE)
+            .where(MAPPING_WORKBOOK_ARTICLE.WORKBOOK_ID.eq(query.workbookId))
+            .fetchOne(0, Int::class.java)
     }
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountWorkbookMappedArticlesQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountWorkbookMappedArticlesQuery.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.subscription.query
+
+data class CountWorkbookMappedArticlesQuery(
+    val workbookId: Long
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountWorkbookSubscriptionQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountWorkbookSubscriptionQuery.kt
@@ -1,6 +1,0 @@
-package com.few.api.repo.dao.subscription.query
-
-data class CountWorkbookSubscriptionQuery(
-    val workbookId: Long,
-    val memberId: Long
-)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt.kt
@@ -1,0 +1,9 @@
+package com.few.api.repo.dao.subscription.query
+
+/**
+ * DeleteAt을 고려하지 않고 모든 워크북 구독 상태를 조회하는 쿼리
+ */
+data class SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt(
+    val workbookId: Long,
+    val memberId: Long
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/WorkbookSubscriptionStatus.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/WorkbookSubscriptionStatus.kt
@@ -1,0 +1,7 @@
+package com.few.api.repo.dao.subscription.record
+
+data class WorkbookSubscriptionStatus(
+    val id: Long,
+    val subHistory: Boolean,
+    val day: Int
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCase.kt
@@ -5,8 +5,9 @@ import com.few.api.domain.subscription.service.dto.InsertMemberDto
 import com.few.api.domain.subscription.service.dto.ReadMemberIdDto
 import com.few.api.repo.dao.subscription.SubscriptionDao
 import com.few.api.repo.dao.subscription.command.InsertWorkbookSubscriptionCommand
-import com.few.api.repo.dao.subscription.query.CountWorkbookSubscriptionQuery
+import com.few.api.repo.dao.subscription.query.SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt
 import com.few.api.domain.subscription.usecase.`in`.SubscribeWorkbookUseCaseIn
+import com.few.api.repo.dao.subscription.query.CountWorkbookMappedArticlesQuery
 import com.few.data.common.code.MemberType
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -25,17 +26,30 @@ class SubscribeWorkbookUseCase(
             InsertMemberDto(useCaseIn.email, MemberType.NORMAL)
         )
 
-        // 이미 구독중인지 확인
-        CountWorkbookSubscriptionQuery(memberId = memberId, workbookId = useCaseIn.workbookId).let { query ->
-            subscriptionDao.selectCountWorkbookSubscription(query).let { cnt ->
-                if (cnt > 0) {
-                    throw RuntimeException("Already subscribed")
+        val subTargetWorkbookId = useCaseIn.workbookId
+        SelectAllWorkbookSubscriptionStatusQueryNotConsiderDeletedAt(memberId = memberId, workbookId = subTargetWorkbookId).let { query ->
+            subscriptionDao.selectAllWorkbookSubscriptionStatus(query).let { subscriptionStatusList ->
+                if (subscriptionStatusList.isNotEmpty()) {
+                    subscriptionStatusList.stream().filter { status ->
+                        status.id == query.workbookId
+                    }.findAny().get().let { status ->
+                        InsertWorkbookSubscriptionCommand(memberId = memberId, workbookId = subTargetWorkbookId).let { command ->
+                            if (status.subHistory) {
+                                CountWorkbookMappedArticlesQuery(subTargetWorkbookId).let { query ->
+                                    subscriptionDao.countWorkbookMappedArticles(query)
+                                }?.let { lastDay ->
+                                    if (lastDay <= (status.day)) {
+                                        throw RuntimeException("이미 학습을 완료한 워크북입니다.")
+                                    }
+                                    subscriptionDao.reSubscribeWorkbookSubscription(command)
+                                }
+                            } else {
+                                subscriptionDao.insertWorkbookSubscription(command)
+                            }
+                        }
+                    }
                 }
             }
         }
-
-        subscriptionDao.insertWorkbookSubscription(
-            InsertWorkbookSubscriptionCommand(memberId = memberId, workbookId = useCaseIn.workbookId)
-        )
     }
 }


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #120

💁‍♂️ PR 내용
----
- 구독해지 후 구독하는 경우 고려하여 구독 API 수정

🙏 작업
----
- 구독 상태를 확인한 이후 구독을 진행하도록 수정

1. 멤버의 워크북에 대한 구독 정보 조회
2. 구독에 따른 구독 정보 갱신/추가 로직 진행 (* 워크북 학습을 모두 완료한 경우 예외 발행)

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
