### PR TITLE
[Feat/#132] 문서 저장 및 변환 모듈 구현

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -38,4 +38,7 @@ object DependencyVersion {
 
     /** aws-sdk */
     const val AWS_SDK = "1.12.220"
+
+    /** commonmark */
+    const val COMMONMARK = "0.22.0"
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -11,4 +11,10 @@ dependencies {
     implementation("io.minio:minio:${DependencyVersion.MINIO}")
     // s3
     implementation("com.amazonaws:aws-java-sdk-s3:${DependencyVersion.AWS_SDK}")
+
+    // commonmark - markdown to html
+    implementation("org.commonmark:commonmark:${DependencyVersion.COMMONMARK}")
+
+    // jsoup
+    implementation("org.jsoup:jsoup:1.15.3")
 }

--- a/storage/src/main/kotlin/com/few/storage/GetPreSignedObjectUrlService.kt
+++ b/storage/src/main/kotlin/com/few/storage/GetPreSignedObjectUrlService.kt
@@ -1,0 +1,6 @@
+package com.few.storage
+
+interface GetPreSignedObjectUrlService {
+
+    fun execute(image: String): String?
+}

--- a/storage/src/main/kotlin/com/few/storage/PutObjectService.kt
+++ b/storage/src/main/kotlin/com/few/storage/PutObjectService.kt
@@ -1,0 +1,8 @@
+package com.few.storage
+
+import java.io.File
+
+interface PutObjectService<T> {
+
+    fun execute(name: String, file: File): T?
+}

--- a/storage/src/main/kotlin/com/few/storage/RemoveObjectService.kt
+++ b/storage/src/main/kotlin/com/few/storage/RemoveObjectService.kt
@@ -1,0 +1,5 @@
+package com.few.storage
+
+interface RemoveObjectService {
+    fun execute(name: String): Boolean
+}

--- a/storage/src/main/kotlin/com/few/storage/document/client/DocumentStoreClient.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/client/DocumentStoreClient.kt
@@ -1,0 +1,11 @@
+package com.few.storage.document.client
+
+import com.few.storage.document.client.dto.DocumentGetPreSignedObjectUrlArgs
+import com.few.storage.document.client.dto.DocumentPutObjectArgs
+import com.few.storage.document.client.dto.DocumentWriteResponse
+
+interface DocumentStoreClient {
+    fun getPreSignedObjectUrl(args: DocumentGetPreSignedObjectUrlArgs): String?
+
+    fun putObject(args: DocumentPutObjectArgs): DocumentWriteResponse?
+}

--- a/storage/src/main/kotlin/com/few/storage/document/client/S3DocumentStoreClient.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/client/S3DocumentStoreClient.kt
@@ -1,0 +1,56 @@
+package com.few.storage.document.client
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.few.storage.document.client.dto.DocumentGetPreSignedObjectUrlArgs
+import com.few.storage.document.client.dto.DocumentPutObjectArgs
+import com.few.storage.document.client.dto.DocumentWriteResponse
+import com.few.storage.document.client.dto.toS3Args
+import com.few.storage.image.client.dto.toS3Args
+import org.slf4j.LoggerFactory
+
+class S3DocumentStoreClient(
+    private val s3client: AmazonS3Client,
+    private val region: String
+) : DocumentStoreClient {
+
+    private val log = LoggerFactory.getLogger(S3DocumentStoreClient::class.java)
+
+    override fun getPreSignedObjectUrl(args: DocumentGetPreSignedObjectUrlArgs): String? {
+        args.toS3Args()
+            .let { s3 ->
+                try {
+                    s3client.generatePresignedUrl(s3)
+                        .let { url ->
+                            return url.toString()
+                        }
+                } catch (e: Exception) {
+                    log.debug("Failed to get presigned url for object: ${args.imagePath}")
+                    log.warn(e.message)
+                    log.warn(e.stackTraceToString())
+                    return null
+                }
+            }
+    }
+
+    override fun putObject(args: DocumentPutObjectArgs): DocumentWriteResponse? {
+        args.toS3Args()
+            .let { s3 ->
+                try {
+                    s3client.putObject(s3).let { owr ->
+                        return DocumentWriteResponse(
+                            s3.bucketName,
+                            region,
+                            args.imagePath,
+                            owr.eTag ?: "",
+                            owr.versionId ?: ""
+                        )
+                    }
+                } catch (e: Exception) {
+                    log.debug("Failed to put object: ${args.imagePath}")
+                    log.warn(e.message)
+                    log.warn(e.stackTraceToString())
+                    return null
+                }
+            }
+    }
+}

--- a/storage/src/main/kotlin/com/few/storage/document/client/dto/DocumentObjectArgs.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/client/dto/DocumentObjectArgs.kt
@@ -1,0 +1,54 @@
+package com.few.storage.document.client.dto
+
+import com.amazonaws.HttpMethod
+import com.amazonaws.services.s3.model.DeleteObjectRequest
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
+import org.apache.http.entity.ContentType
+import java.io.InputStream
+
+fun DocumentGetPreSignedObjectUrlArgs.toS3Args(): GeneratePresignedUrlRequest {
+    return GeneratePresignedUrlRequest(
+        this.bucket,
+        this.imagePath,
+        HttpMethod.valueOf(this.method)
+    )
+}
+
+fun DocumentRemoveObjectArgs.toS3Args(): DeleteObjectRequest {
+    return DeleteObjectRequest(this.bucket, this.imagePath)
+}
+
+fun DocumentPutObjectArgs.toS3Args(): PutObjectRequest {
+    val objectSize = this.objectSize
+    return PutObjectRequest(
+        this.bucket,
+        this.imagePath,
+        this.stream,
+        ObjectMetadata().apply {
+            contentType = this.contentType
+            contentLength = objectSize
+        }
+    )
+}
+
+data class DocumentGetPreSignedObjectUrlArgs(
+    val bucket: String,
+    val imagePath: String,
+    val method: String
+)
+
+data class DocumentPutObjectArgs(
+    val bucket: String,
+    val imagePath: String,
+    val stream: InputStream,
+    val objectSize: Long,
+    val partSize: Long,
+    val contentType: ContentType = ContentType.IMAGE_JPEG
+)
+
+data class DocumentRemoveObjectArgs(
+    val bucket: String,
+    val imagePath: String
+)

--- a/storage/src/main/kotlin/com/few/storage/document/client/dto/DocumentWriteResponse.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/client/dto/DocumentWriteResponse.kt
@@ -1,0 +1,9 @@
+package com.few.storage.document.client.dto
+
+data class DocumentWriteResponse(
+    val bucket: String,
+    val region: String,
+    val `object`: String,
+    val etag: String,
+    val versionId: String
+)

--- a/storage/src/main/kotlin/com/few/storage/document/client/util/DocumentArgsGenerator.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/client/util/DocumentArgsGenerator.kt
@@ -1,0 +1,25 @@
+package com.few.storage.document.client.util
+
+import com.few.storage.document.client.dto.DocumentGetPreSignedObjectUrlArgs
+import com.few.storage.document.client.dto.DocumentPutObjectArgs
+import com.few.storage.document.client.dto.DocumentRemoveObjectArgs
+import org.apache.http.entity.ContentType
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+
+class DocumentArgsGenerator {
+    companion object {
+        fun preSignedUrl(bucket: String, document: String): DocumentGetPreSignedObjectUrlArgs {
+            return DocumentGetPreSignedObjectUrlArgs(bucket, document, "GET")
+        }
+
+        fun putDocument(bucket: String, name: String, document: File): DocumentPutObjectArgs {
+            return DocumentPutObjectArgs(bucket, name, BufferedInputStream(FileInputStream(document)), document.length(), -1, ContentType.APPLICATION_OCTET_STREAM)
+        }
+
+        fun remove(bucket: String, document: String): DocumentRemoveObjectArgs {
+            return DocumentRemoveObjectArgs(bucket, document)
+        }
+    }
+}

--- a/storage/src/main/kotlin/com/few/storage/document/config/DocumentStorageConfig.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/config/DocumentStorageConfig.kt
@@ -1,0 +1,19 @@
+package com.few.storage.document.config
+
+import com.few.storage.config.ClientConfig
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+@Configuration
+@ComponentScan(basePackages = [DocumentStorageConfig.BASE_PACKAGE])
+@Import(ClientConfig::class)
+class DocumentStorageConfig {
+    companion object {
+        const val BASE_PACKAGE = "com.few.storage.document"
+        const val SERVICE_NAME = "documentStorage"
+        const val MODULE_NAME = "storage-document"
+        const val BEAN_NAME_PREFIX = "documentStore"
+        const val PROPERTY_PREFIX = SERVICE_NAME + "." + MODULE_NAME
+    }
+}

--- a/storage/src/main/kotlin/com/few/storage/document/config/S3DocumentStoreConfig.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/config/S3DocumentStoreConfig.kt
@@ -1,0 +1,43 @@
+package com.few.storage.document.config
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.few.storage.config.ClientConfig
+import com.few.storage.document.client.DocumentStoreClient
+import com.few.storage.document.client.S3DocumentStoreClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.context.event.ContextRefreshedEvent
+
+@Configuration
+@Import(ClientConfig::class)
+class S3DocumentStoreConfig(
+    @Value("\${document.store.bucket-name}") val bucket: String,
+    @Value("\${storage.region}") val region: String
+) : ApplicationListener<ContextRefreshedEvent> {
+    var log: Logger = LoggerFactory.getLogger(S3DocumentStoreConfig::class.java)
+
+    private var client: AmazonS3Client? = null
+
+    override fun onApplicationEvent(event: ContextRefreshedEvent) {
+        client?.let { client ->
+            client.listBuckets().let { buckets ->
+                if (buckets.none { it.name == bucket }) {
+                    client.createBucket(bucket)
+                    log.info("Create bucket $bucket")
+                }
+                log.info("Bucket $bucket already exists")
+            }
+        }
+    }
+
+    @Bean
+    fun s3DocumentStoreClient(s3StorageClient: AmazonS3Client): DocumentStoreClient {
+        client = s3StorageClient
+        return S3DocumentStoreClient(client!!, region)
+    }
+}

--- a/storage/src/main/kotlin/com/few/storage/document/service/ConvertDocumentService.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/service/ConvertDocumentService.kt
@@ -1,0 +1,24 @@
+package com.few.storage.document.service
+
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+import org.jsoup.Jsoup
+import org.springframework.stereotype.Service
+
+@Service
+class ConvertDocumentService {
+
+    companion object {
+        val parser = Parser.builder().build()
+        val htmlRenderer = HtmlRenderer.builder().build()
+        val HTML_HEADER =
+            "<!DOCTYPE html> <html></html>"
+    }
+
+    fun mdToHtml(md: String): String {
+        val html = Jsoup.parse(HTML_HEADER)
+        val body = htmlRenderer.render(parser.parse(md))
+        html.body().append(body)
+        return html.toString()
+    }
+}

--- a/storage/src/main/kotlin/com/few/storage/document/service/GetPreSignedDocumentUrlService.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/service/GetPreSignedDocumentUrlService.kt
@@ -1,0 +1,7 @@
+package com.few.storage.document.service
+
+import com.few.storage.GetPreSignedObjectUrlService
+
+interface GetPreSignedDocumentUrlService : GetPreSignedObjectUrlService {
+    override fun execute(image: String): String?
+}

--- a/storage/src/main/kotlin/com/few/storage/document/service/PutDocumentService.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/service/PutDocumentService.kt
@@ -1,0 +1,9 @@
+package com.few.storage.document.service
+
+import com.few.storage.PutObjectService
+import com.few.storage.document.client.dto.DocumentWriteResponse
+import java.io.File
+
+interface PutDocumentService : PutObjectService<DocumentWriteResponse> {
+    override fun execute(name: String, file: File): DocumentWriteResponse?
+}

--- a/storage/src/main/kotlin/com/few/storage/document/service/s3/S3GetPreSignedDocumentUrlService.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/service/s3/S3GetPreSignedDocumentUrlService.kt
@@ -1,0 +1,19 @@
+package com.few.storage.document.service.s3
+
+import com.few.storage.document.client.DocumentStoreClient
+import com.few.storage.document.client.util.DocumentArgsGenerator
+import com.few.storage.document.service.GetPreSignedDocumentUrlService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class S3GetPreSignedDocumentUrlService(
+    @Value("\${document.store.bucket-name}") val bucket: String,
+    private val documentStoreClient: DocumentStoreClient
+) : GetPreSignedDocumentUrlService {
+    override fun execute(image: String): String? {
+        DocumentArgsGenerator.preSignedUrl(bucket, image).let { args ->
+            return documentStoreClient.getPreSignedObjectUrl(args)
+        }
+    }
+}

--- a/storage/src/main/kotlin/com/few/storage/document/service/s3/S3PutDocumentService.kt
+++ b/storage/src/main/kotlin/com/few/storage/document/service/s3/S3PutDocumentService.kt
@@ -1,0 +1,21 @@
+package com.few.storage.document.service.s3
+
+import com.few.storage.document.client.DocumentStoreClient
+import com.few.storage.document.client.dto.DocumentWriteResponse
+import com.few.storage.document.client.util.DocumentArgsGenerator
+import com.few.storage.document.service.PutDocumentService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.io.File
+
+@Service
+class S3PutDocumentService(
+    @Value("\${document.store.bucket-name}") val bucket: String,
+    private val documentStoreClient: DocumentStoreClient
+) : PutDocumentService {
+    override fun execute(name: String, file: File): DocumentWriteResponse? {
+        DocumentArgsGenerator.putDocument(bucket, name, file).let { args ->
+            return documentStoreClient.putObject(args)
+        }
+    }
+}

--- a/storage/src/main/resources/application-storage-local.yml
+++ b/storage/src/main/resources/application-storage-local.yml
@@ -8,5 +8,9 @@ image:
     store:
         bucket-name: picture
 
+document:
+    store:
+        bucket-name: document
+
 cdn:
     url: http://127.0.0.1:9000

--- a/storage/src/main/resources/application-storage-prd.yml
+++ b/storage/src/main/resources/application-storage-prd.yml
@@ -9,5 +9,10 @@ image:
         bucket-name: ${IMAGE_STORE_BUCKET_NAME}
         region: ${STORAGE_REGION}
 
+document:
+    store:
+        bucket-name: ${DOCUMENT_STORE_BUCKET_NAME}
+        region: ${STORAGE_REGION}
+
 cdn:
     url: ${CDN_URL}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #132

💁‍♂️ PR 내용
----
- 문서 저장 및 변환 모듈 구현

🙏 작업
----
- ConvertDocumentService: Md 파일을 html로 변환합니다
- GetPreSignedDocumentUrlService/PutDocumentService: 원본 문서 저장 및 다운 주소를 제공합니다.
- 0c307008f0f51b3ef82ad3bfaab0388afe0885e0 의 공통 인터페이스 선언은 오브젝트 스토어 이미지와 문서를 저장/삭제/조회 하는 과정이 동일하여 추가하였습니다. 이로 이전에 구현한 GetUrlService의 구현을 유현하게 할 수 있습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
