### PR TITLE
[Feat/#131] 이메일 구독 내용 채워서 구현

### DIFF
--- a/batch/src/main/kotlin/com/few/batch/data/common/code/BatchCategoryType.kt
+++ b/batch/src/main/kotlin/com/few/batch/data/common/code/BatchCategoryType.kt
@@ -1,0 +1,27 @@
+package com.few.batch.data.common.code
+
+/**
+ * BatchCategoryType is origin from CategoryType in few-data module.
+ * @see com.few.data.common.code.CategoryType
+ */
+enum class BatchCategoryType(val code: Byte, val displayName: String) {
+    ECONOMY(0, "경제"),
+    IT(10, "IT"),
+    MARKETING(20, "마케팅"),
+    CULTURE(30, "교양"),
+    SCIENCE(40, "과학");
+
+    companion object {
+        fun fromCode(code: Byte): BatchCategoryType? {
+            return entries.find { it.code == code }
+        }
+
+        fun convertToCode(displayName: String): Byte {
+            return entries.find { it.name == displayName }?.code ?: throw IllegalArgumentException("Invalid category name")
+        }
+
+        fun convertToDisplayName(code: Byte): String {
+            return entries.find { it.code == code }?.displayName ?: throw IllegalArgumentException("Invalid category code")
+        }
+    }
+}

--- a/batch/src/main/kotlin/com/few/batch/data/common/code/BatchMemberType.kt
+++ b/batch/src/main/kotlin/com/few/batch/data/common/code/BatchMemberType.kt
@@ -1,0 +1,17 @@
+package com.few.batch.data.common.code
+
+/**
+ * BatchMemberType is origin from MemberType in few-data module.
+ * @see com.few.data.common.code.MemberType
+ */
+enum class BatchMemberType(val code: Byte, val displayName: String) {
+    NORMAL(60, "일반멤버"),
+    ADMIN(0, "어드민멤버"),
+    WRITER(120, "작가멤버");
+
+    companion object {
+        fun fromCode(code: Byte): BatchMemberType? {
+            return values().find { it.code == code }
+        }
+    }
+}

--- a/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
@@ -147,7 +147,7 @@ class WorkBookSubscriberWriter(
                     writerLink = article.writerLink,
                     articleContent = article.articleContent,
                     problemLink = URL("https://www.fewletter.com/problem?articleId=${memberArticle.articleId}"),
-                    unsubscribeLink = URL("https://www.fewletter.com/unsbuscribe?user=${memberEmailRecords[it.memberId]}&workbookId=${it.targetWorkBookId}&articleId=${memberArticle.articleId}")
+                    unsubscribeLink = URL("https://www.fewletter.com/unsubscribe?user=${memberEmailRecords[it.memberId]}&workbookId=${it.targetWorkBookId}&articleId=${memberArticle.articleId}")
                 )
             }
             return@map it.memberId to

--- a/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
@@ -1,19 +1,20 @@
 package com.few.batch.service.article.writer
 
+import com.few.batch.data.common.code.BatchCategoryType
+import com.few.batch.data.common.code.BatchMemberType
 import com.few.batch.service.article.dto.WorkBookSubscriberItem
 import com.few.batch.service.article.dto.toMemberIds
 import com.few.batch.service.article.dto.toTargetWorkBookIds
 import com.few.batch.service.article.dto.toTargetWorkBookProgress
 import com.few.email.service.article.SendArticleEmailService
+import com.few.email.service.article.dto.Content
 import com.few.email.service.article.dto.SendArticleEmailArgs
-import jooq.jooq_dsl.tables.ArticleIfo
-import jooq.jooq_dsl.tables.MappingWorkbookArticle
-import jooq.jooq_dsl.tables.Member
-import jooq.jooq_dsl.tables.Subscription
+import jooq.jooq_dsl.tables.*
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.net.URL
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -39,22 +40,39 @@ data class MemberReceiveArticles(
     }
 }
 
+data class ArticleContent(
+    val id: Long,
+    val category: String, // todo fix
+    val articleTitle: String,
+    val articleContent: String,
+    val writerName: String,
+    val writerLink: URL
+)
+
+fun List<ArticleContent>.peek(articleId: Long): ArticleContent {
+    return this.find {
+        it.id == articleId
+    } ?: throw IllegalArgumentException("article not found")
+}
+
 @Component
 class WorkBookSubscriberWriter(
     private val dslContext: DSLContext,
     private val sendArticleEmailService: SendArticleEmailService
 ) {
 
+    companion object {
+        private const val ARTICLE_SUBJECT_TEMPLATE = "Day%d %s"
+        private const val ARTICLE_TEMPLATE = "article"
+    }
+
     @Transactional
     fun execute(items: List<WorkBookSubscriberItem>): Map<Any, Any> {
         val memberT = Member.MEMBER
         val mappingWorkbookArticleT = MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE
         val articleIfoT = ArticleIfo.ARTICLE_IFO
+        val articleMstT = ArticleMst.ARTICLE_MST
         val subscriptionT = Subscription.SUBSCRIPTION
-
-        val ARTICLE_SUBJECT = "${LocalDate.now()} 일자 학습 아티클"
-        val ARTICLE_TEMPLATE = "article" // todo fix
-        val ARTICLE_STYLE = "style" // todo fix
 
         val memberIds = items.toMemberIds()
         val targetWorkBookIds = items.toTargetWorkBookIds()
@@ -90,25 +108,55 @@ class WorkBookSubscriberWriter(
             MemberReceiveArticles(it)
         }
 
-        /** 구독자들이 받을 학습지 정보를 기준으로 학습지의 내용을 조회한다.*/
-        val articleContentsMap = dslContext.select(
-            articleIfoT.ARTICLE_MST_ID,
-            articleIfoT.CONTENT
+        /** 구독자들이 받을 학습지 정보를 기준으로 학습지 관련 정보를 조회한다.*/
+        val articleContents = dslContext.select(
+            articleIfoT.ARTICLE_MST_ID.`as`(ArticleContent::id.name),
+            articleIfoT.CONTENT.`as`(ArticleContent::articleContent.name),
+            articleMstT.TITLE.`as`(ArticleContent::articleTitle.name),
+            articleMstT.CATEGORY_CD.`as`(ArticleContent::category.name),
+            DSL.jsonGetAttributeAsText(memberT.DESCRIPTION, "name").`as`(ArticleContent::writerName.name),
+            DSL.jsonGetAttribute(memberT.DESCRIPTION, "url").`as`(ArticleContent::writerLink.name)
         )
             .from(articleIfoT)
+            .join(articleMstT)
+            .on(articleIfoT.ARTICLE_MST_ID.eq(articleMstT.ID))
+            .join(memberT)
+            .on(
+                articleMstT.MEMBER_ID.eq(memberT.ID)
+                    .and(memberT.TYPE_CD.eq(BatchMemberType.WRITER.code))
+            )
             .where(articleIfoT.ARTICLE_MST_ID.`in`(memberReceiveArticles.getArticleIds()))
             .and(articleIfoT.DELETED_AT.isNull)
-            .fetch()
-            .intoMap(articleIfoT.ARTICLE_MST_ID, articleIfoT.CONTENT)
+            .fetchInto(ArticleContent::class.java)
 
         val memberSuccessRecords = memberIds.associateWith { true }.toMutableMap()
         val failRecords = mutableMapOf<String, ArrayList<Long>>()
         // todo check !! target is not null
+        val date = LocalDate.now()
         val emailServiceArgs = items.map {
             val toEmail = memberEmailRecords[it.memberId]!!
             val memberArticle = memberReceiveArticles.getByWorkBookIdAndDayCol(it.targetWorkBookId, it.progress + 1)
-            val articleContent = articleContentsMap[memberArticle.articleId]!!
-            return@map it.memberId to SendArticleEmailArgs(toEmail, ARTICLE_SUBJECT, ARTICLE_TEMPLATE, articleContent, ARTICLE_STYLE)
+            val articleContent = articleContents.peek(memberArticle.articleId).let { article ->
+                Content(
+                    articleLink = URL("https://www.fewletter.com/article/${memberArticle.articleId}"),
+                    currentDate = date,
+                    category = BatchCategoryType.convertToDisplayName(article.category.toByte()),
+                    articleDay = memberArticle.dayCol.toInt(),
+                    articleTitle = article.articleTitle,
+                    writerName = article.writerName,
+                    writerLink = article.writerLink,
+                    articleContent = article.articleContent,
+                    problemLink = URL("https://www.fewletter.com/problem?articleId=${memberArticle.articleId}"),
+                    unsubscribeLink = URL("https://www.fewletter.com/unsbuscribe?user=${memberEmailRecords[it.memberId]}&workbookId=${it.targetWorkBookId}&articleId=${memberArticle.articleId}")
+                )
+            }
+            return@map it.memberId to
+                SendArticleEmailArgs(
+                    toEmail,
+                    ARTICLE_SUBJECT_TEMPLATE.format(memberArticle.dayCol, articleContent.articleTitle),
+                    ARTICLE_TEMPLATE,
+                    articleContent
+                )
         }
 
         // todo refactoring to send email in parallel or batch

--- a/batch/src/test/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriterTestSetHelper.kt
+++ b/batch/src/test/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriterTestSetHelper.kt
@@ -1,12 +1,15 @@
 package com.few.batch.service.article.writer
 
+import com.few.batch.data.common.code.BatchCategoryType
+import com.few.batch.data.common.code.BatchMemberType
 import com.few.batch.service.article.dto.WorkBookSubscriberItem
-import jooq.jooq_dsl.tables.ArticleIfo
-import jooq.jooq_dsl.tables.MappingWorkbookArticle
-import jooq.jooq_dsl.tables.Member
-import jooq.jooq_dsl.tables.Subscription
+import com.few.email.service.article.dto.Content
+import jooq.jooq_dsl.tables.*
 import org.jooq.DSLContext
+import org.jooq.JSON
 import org.springframework.boot.test.context.TestComponent
+import java.net.URL
+import java.time.LocalDate
 import kotlin.random.Random
 
 fun List<TestWorkBookSubscriberDto>.toServiceDto(): List<WorkBookSubscriberItem> {
@@ -23,7 +26,14 @@ data class TestWorkBookSubscriberDto(
     val memberId: Long,
     val targetWorkBookId: Long,
     val progress: Long,
-    val content: String
+    val content: Content
+)
+
+data class ArticleDto(
+    val articleId: Long,
+    val dayCol: Int,
+    val content: String,
+    val title: String
 )
 
 @TestComponent
@@ -36,9 +46,18 @@ class WorkBookSubscriberWriterTestSetHelper(
             dslContext.insertInto(Member.MEMBER)
                 .set(Member.MEMBER.ID, i.toLong())
                 .set(Member.MEMBER.EMAIL, "member$i@gmail.com")
-                .set(Member.MEMBER.TYPE_CD, 0) // todo fix
+                .set(Member.MEMBER.TYPE_CD, BatchMemberType.NORMAL.code)
                 .execute()
         }
+    }
+
+    fun setUpWriter(id: Long) {
+        dslContext.insertInto(Member.MEMBER)
+            .set(Member.MEMBER.ID, id)
+            .set(Member.MEMBER.EMAIL, "writer@gmail.com")
+            .set(Member.MEMBER.TYPE_CD, BatchMemberType.WRITER.code)
+            .set(Member.MEMBER.DESCRIPTION, JSON.valueOf("{\"url\": \"http://localhost:8080\", \"name\": \"writer\"}"))
+            .execute()
     }
 
     fun setUpSubscriptions(start: Int = 1, count: Int, workbookId: Long = 1) {
@@ -51,12 +70,24 @@ class WorkBookSubscriberWriterTestSetHelper(
         }
     }
 
-    fun setUpMappingWorkbookArticle(start: Int = 1, count: Int, workbookId: Long = 1, dayCorrection: Int = 0) {
+    fun setUpMappingWorkbookArticle(start: Int = 1, count: Int, workbookId: Long = 1, dayCorrection: Int = 1) {
         for (i in start..count) {
             dslContext.insertInto(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE)
                 .set(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.WORKBOOK_ID, workbookId)
                 .set(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.ARTICLE_ID, i.toLong())
                 .set(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DAY_COL, i - dayCorrection)
+                .execute()
+        }
+    }
+
+    fun setUpArticleMst(start: Int = 1, count: Int, writerId: Long) {
+        for (i in start..count) {
+            dslContext.insertInto(ArticleMst.ARTICLE_MST)
+                .set(ArticleMst.ARTICLE_MST.ID, i.toLong())
+                .set(ArticleMst.ARTICLE_MST.TITLE, "title$i")
+                .set(ArticleMst.ARTICLE_MST.MEMBER_ID, writerId)
+                .set(ArticleMst.ARTICLE_MST.CATEGORY_CD, BatchCategoryType.fromCode(0)!!.code)
+                .set(ArticleMst.ARTICLE_MST.MAIN_IMAGE_URL, "http://localhost:8080")
                 .execute()
         }
     }
@@ -92,11 +123,36 @@ class WorkBookSubscriberWriterTestSetHelper(
                         .and(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DELETED_AT.isNull)
                         .fetchOneInto(String::class.java)
 
+                    val articleDto = dslContext.select(
+                        MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.ARTICLE_ID,
+                        MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DAY_COL,
+                        ArticleIfo.ARTICLE_IFO.CONTENT,
+                        ArticleMst.ARTICLE_MST.TITLE
+                    ).from(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE)
+                        .join(ArticleIfo.ARTICLE_IFO)
+                        .on(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.ARTICLE_ID.eq(ArticleIfo.ARTICLE_IFO.ARTICLE_MST_ID))
+                        .join(ArticleMst.ARTICLE_MST)
+                        .on(ArticleIfo.ARTICLE_IFO.ARTICLE_MST_ID.eq(ArticleMst.ARTICLE_MST.ID))
+                        .where(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.WORKBOOK_ID.eq(workbookId))
+                        .and(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DAY_COL.eq(it[Subscription.SUBSCRIPTION.PROGRESS].toInt() + 1))
+                        .fetchOneInto(ArticleDto::class.java)
+
                     val dto = TestWorkBookSubscriberDto(
                         memberId = it[Subscription.SUBSCRIPTION.MEMBER_ID],
                         targetWorkBookId = workbookId,
                         progress = it[Subscription.SUBSCRIPTION.PROGRESS],
-                        content = content!!
+                        content = Content(
+                            articleLink = URL("https://www.fewletter.com/article/${articleDto!!.articleId}"),
+                            currentDate = LocalDate.now(),
+                            category = BatchCategoryType.fromCode(0)!!.displayName,
+                            articleDay = articleDto.dayCol,
+                            articleTitle = articleDto.title,
+                            writerName = "writer",
+                            writerLink = URL("http://localhost:8080"),
+                            articleContent = articleDto.content,
+                            problemLink = URL("https://www.fewletter.com/problem?articleId=${articleDto.articleId}"),
+                            unsubscribeLink = URL("https://www.fewletter.com/unsbuscribe?user=member${it[Subscription.SUBSCRIPTION.MEMBER_ID]}@gmail.com&workbookId=$workbookId&articleId=${articleDto.articleId}")
+                        )
                     )
                     items.add(dto)
                 }

--- a/data/src/main/kotlin/com/few/data/common/code/CategoryType.kt
+++ b/data/src/main/kotlin/com/few/data/common/code/CategoryType.kt
@@ -1,5 +1,8 @@
 package com.few.data.common.code
 
+/**
+ * @see com.few.batch.data.common.code.BatchCategoryType
+ */
 enum class CategoryType(val code: Byte, val displayName: String) {
     POLITICS(0, "정치"),
     ECONOMY(10, "경제"),

--- a/data/src/main/kotlin/com/few/data/common/code/MemberType.kt
+++ b/data/src/main/kotlin/com/few/data/common/code/MemberType.kt
@@ -1,5 +1,8 @@
 package com.few.data.common.code
 
+/**
+ * @see com.few.batch.data.common.code.BatchMemberType
+ */
 enum class MemberType(val code: Byte, val displayName: String) {
     NORMAL(60, "일반멤버"),
     ADMIN(0, "어드민멤버"),

--- a/email/src/main/kotlin/com/few/email/sender/dto/SendMailArgs.kt
+++ b/email/src/main/kotlin/com/few/email/sender/dto/SendMailArgs.kt
@@ -1,33 +1,9 @@
 package com.few.email.sender.dto
 
-abstract class SendMailArgs<C, P>(
-    val to: String,
-    val subject: String,
-    val template: String,
-    private val content: C,
-    private val properties: P
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SendMailArgs<*, *>
-
-        if (to != other.to) return false
-        if (subject != other.subject) return false
-        if (template != other.template) return false
-        if (content != other.content) return false
-        if (properties != other.properties) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = to.hashCode()
-        result = 31 * result + subject.hashCode()
-        result = 31 * result + template.hashCode()
-        result = 31 * result + (content?.hashCode() ?: 0)
-        result = 31 * result + (properties?.hashCode() ?: 0)
-        return result
-    }
+interface SendMailArgs<C, P> {
+    val to: String
+    val subject: String
+    val template: String
+    val content: C
+    val properties: P
 }

--- a/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
@@ -19,7 +19,7 @@ class SendArticleEmailService(
 
     override fun getHtml(args: SendArticleEmailArgs): String {
         val context = Context()
-        context.setVariable("articleLink", args.articleContent.articleLink)
+        context.setVariable("articleLink", args.articleContent.articleLink.toString() + "?fromEmail=true")
         context.setVariable(
             "currentDate",
             args.articleContent.currentDate.format(

--- a/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
 import java.time.format.DateTimeFormatter
+import java.util.*
 
 @Component
 class SendArticleEmailService(
@@ -19,7 +20,14 @@ class SendArticleEmailService(
     override fun getHtml(args: SendArticleEmailArgs): String {
         val context = Context()
         context.setVariable("articleLink", args.articleContent.articleLink)
-        context.setVariable("currentDate", args.articleContent.currentDate.format(DateTimeFormatter.ofPattern("yyyy/MM/dd EEEE")))
+        context.setVariable(
+            "currentDate",
+            args.articleContent.currentDate.format(
+                DateTimeFormatter.ofPattern("yyyy/MM/dd EEEE").withLocale(
+                    Locale.KOREA
+                )
+            )
+        )
         context.setVariable("category", args.articleContent.category)
         context.setVariable("articleDay", "Day" + args.articleContent.articleDay)
         context.setVariable("articleTitle", args.articleContent.articleTitle)

--- a/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
@@ -19,23 +19,23 @@ class SendArticleEmailService(
 
     override fun getHtml(args: SendArticleEmailArgs): String {
         val context = Context()
-        context.setVariable("articleLink", args.articleContent.articleLink.toString() + "?fromEmail=true")
+        context.setVariable("articleLink", args.content.articleLink.toString() + "?fromEmail=true")
         context.setVariable(
             "currentDate",
-            args.articleContent.currentDate.format(
+            args.content.currentDate.format(
                 DateTimeFormatter.ofPattern("yyyy/MM/dd EEEE").withLocale(
                     Locale.KOREA
                 )
             )
         )
-        context.setVariable("category", args.articleContent.category)
-        context.setVariable("articleDay", "Day" + args.articleContent.articleDay)
-        context.setVariable("articleTitle", args.articleContent.articleTitle)
-        context.setVariable("writerName", args.articleContent.writerName)
-        context.setVariable("writerLink", args.articleContent.writerLink)
-        context.setVariable("articleContent", args.articleContent.articleContent)
-        context.setVariable("problemLink", args.articleContent.problemLink)
-        context.setVariable("unsubscribeLink", args.articleContent.unsubscribeLink)
+        context.setVariable("category", args.content.category)
+        context.setVariable("articleDay", "Day" + args.content.articleDay)
+        context.setVariable("articleTitle", args.content.articleTitle)
+        context.setVariable("writerName", args.content.writerName)
+        context.setVariable("writerLink", args.content.writerLink)
+        context.setVariable("articleContent", args.content.articleContent)
+        context.setVariable("problemLink", args.content.problemLink)
+        context.setVariable("unsubscribeLink", args.content.unsubscribeLink)
         return templateEngine.process(args.template, context)
     }
 }

--- a/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
@@ -7,6 +7,7 @@ import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Component
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
+import java.time.format.DateTimeFormatter
 
 @Component
 class SendArticleEmailService(
@@ -17,8 +18,16 @@ class SendArticleEmailService(
 
     override fun getHtml(args: SendArticleEmailArgs): String {
         val context = Context()
-        context.setVariable("content", args.articleContent)
-        context.setVariable("style", args.style)
+        context.setVariable("articleLink", args.articleContent.articleLink)
+        context.setVariable("currentDate", args.articleContent.currentDate.format(DateTimeFormatter.ofPattern("yyyy/MM/dd EEEE")))
+        context.setVariable("category", args.articleContent.category)
+        context.setVariable("articleDay", "Day" + args.articleContent.articleDay)
+        context.setVariable("articleTitle", args.articleContent.articleTitle)
+        context.setVariable("writerName", args.articleContent.writerName)
+        context.setVariable("writerLink", args.articleContent.writerLink)
+        context.setVariable("articleContent", args.articleContent.articleContent)
+        context.setVariable("problemLink", args.articleContent.problemLink)
+        context.setVariable("unsubscribeLink", args.articleContent.unsubscribeLink)
         return templateEngine.process(args.template, context)
     }
 }

--- a/email/src/main/kotlin/com/few/email/service/article/dto/SendArticleEmailArgs.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/dto/SendArticleEmailArgs.kt
@@ -1,11 +1,26 @@
 package com.few.email.service.article.dto
 
 import com.few.email.sender.dto.SendMailArgs
+import java.net.URL
+import java.time.LocalDate
 
 class SendArticleEmailArgs(
     to: String,
     subject: String,
     template: String,
+    val articleContent: Content,
+    val style: String = ""
+) : SendMailArgs<Content, String>(to, subject, template, articleContent, style)
+
+data class Content(
+    val articleLink: URL,
+    val currentDate: LocalDate,
+    val category: String,
+    val articleDay: Int,
+    val articleTitle: String,
+    val writerName: String,
+    val writerLink: URL,
     val articleContent: String,
-    val style: String
-) : SendMailArgs<String, String>(to, subject, template, articleContent, style)
+    val problemLink: URL,
+    val unsubscribeLink: URL
+)

--- a/email/src/main/kotlin/com/few/email/service/article/dto/SendArticleEmailArgs.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/dto/SendArticleEmailArgs.kt
@@ -4,13 +4,13 @@ import com.few.email.sender.dto.SendMailArgs
 import java.net.URL
 import java.time.LocalDate
 
-class SendArticleEmailArgs(
-    to: String,
-    subject: String,
-    template: String,
-    val articleContent: Content,
-    val style: String = ""
-) : SendMailArgs<Content, String>(to, subject, template, articleContent, style)
+data class SendArticleEmailArgs(
+    override val to: String,
+    override val subject: String,
+    override val template: String,
+    override val content: Content,
+    override val properties: String = ""
+) : SendMailArgs<Content, String>
 
 data class Content(
     val articleLink: URL,

--- a/email/src/main/resources/templates/article.html
+++ b/email/src/main/resources/templates/article.html
@@ -1,126 +1,179 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" lang="en">
+<html lang="KR">
 
 <head>
-  <title></title>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"><!--[if mso]><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch><o:AllowPNG/></o:OfficeDocumentSettings></xml><![endif]--><!--[if !mso]><!-->
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;800;900" rel="stylesheet" type="text/css"><!--<![endif]-->
-  <style>
-      ${style}
-  </style>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+    <title>FEW</title>
 </head>
 
-<body style="background-color: #f8f8ff; margin: 0; padding: 0; -webkit-text-size-adjust: none; text-size-adjust: none;">
-<table class="nl-container" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #f8f8ff;">
-  <tbody>
-  <tr>
-    <td>
-      <table class="row row-1" align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
-        <tbody>
-        <tr>
-          <td>
-            <table class="row-content stack" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #000000; width: 700px; margin: 0 auto;" width="700">
-              <tbody>
-              <tr>
-                <td class="column column-1" width="100%" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; padding-bottom: 5px; padding-top: 5px; vertical-align: top; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;">
-                  <table class="empty_block block-1" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
-                    <tr>
-                      <td class="pad">
-                        <div></div>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              </tbody>
+<body style="
+      margin: 0 auto;
+      width: 100%;
+      max-width: 480px;
+      font-family: 'Pretendard Variable', Pretendard, -apple-system,
+        BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
+        'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+        background-color: #ffffff;
+    ">
+<table align="center" width="100%" cellpadding="0" cellspacing="0"
+       style="max-width: 480px; width: 100%; background-color: #ffffff; color : #000000">
+    <tr>
+        <td style="padding: 30px 20px">
+            <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td align="center" style="width: 100%; height: auto;">
+                        <img src="https://eehhqckznniu25210545.cdn.ntruss.com/images/2024-07-05/B4RRKVh8aEHCHBTS.png"
+                             alt="few_logo" style="display: block; margin: 0 auto; width: 335px; height: 100px" />
+                    </td>
+                </tr>
+                <tr>
+                    <td align="center" style="padding: 12px 0">
+                        <p style="
+                    margin: 0;
+                    font-size: 14px;
+                    line-height: 21px;
+                    font-weight: 500;
+                  " id="current-date" th:text="${currentDate}"></p>
+                        <a th:href="${articleLink}" target="_blank" style="
+                    text-decoration: underline;
+                    color: #484848;
+                    font-size: 14px;
+                    line-height: 21px;
+                    font-weight: 500;
+                  ">웹으로 읽을래요!</a>
+                    </td>
+                </tr>
             </table>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-      <table class="row row-2" align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
-        <tbody>
-        <tr>
-          <td>
-            <table class="row-content stack" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #1eb649; color: #000000; width: 700px; margin: 0 auto;" width="700">
-              <tbody>
-              <tr>
-                <td class="column column-1" width="100%" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; padding-bottom: 10px; padding-left: 10px; padding-right: 10px; padding-top: 10px; vertical-align: top; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;">
-                  <table class="image_block block-1" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
-                    <tr>
-                      <td class="pad" style="width:100%;padding-right:0px;padding-left:0px;">
-                        <div class="alignment" align="center" style="line-height:10px">
-                          <!--todo fix image-->
-                          <div class="fullWidth" style="max-width: 420px;"><img src="https://github.com/YAPP-Github/24th-Web-Team-1-BE/assets/102807742/94c0d873-254c-41de-af5b-2fee3de394de" style="display: block; height: auto; border: 0; width: 100%;" width="420" alt="Alternate text" title="Alternate text"></div>
-                        </div>
-                      </td>
-                    </tr>
-                  </table>
-                  <div class="spacer_block block-2 mobile_hide" style="height:30px;line-height:30px;font-size:1px;">&#8202;</div>
-                  <div class="spacer_block block-3" style="height:10px;line-height:10px;font-size:1px;">&#8202;</div>
-                  <table class="paragraph_block block-4" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word;">
-                    <tr>
-                      <td class="pad" style="padding-bottom:5px;padding-left:10px;padding-right:10px;padding-top:10px;">
-                        <div style="color:#ffffff;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;font-size:25px;line-height:150%;text-align:center;mso-line-height-alt:37.5px;">
-                          <p style="margin: 0; word-break: break-word;"><strong>이메일 인증 번호</strong></p>
-                        </div>
-                      </td>
-                    </tr>
-                  </table>
-                  <div class="spacer_block block-5" style="height:20px;line-height:20px;font-size:1px;">&#8202;</div>
-                  <table class="paragraph_block block-6" width="100%" border="0" cellpadding="10" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; word-break: break-word;">
-                    <tr>
-                      <td class="pad">
-                        <div style="color:#ffffff;font-family:Montserrat, Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif;font-size:46px;line-height:120%;text-align:center;mso-line-height-alt:55.199999999999996px;">
-                          <p style="margin: 0; word-break: break-word;"><span><strong><span th:text="${content}"></span></strong></span></p>
-                        </div>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              </tbody>
+        </td>
+    </tr>
+
+    <tr>
+        <td style="padding: 20px">
+            <table cellpadding="0" cellspacing="0" border="0" style="table-layout: auto">
+                <tr style="gap: 12px">
+                    <td colspan="1">
+                            <span style="
+                    background-color: #f5f5f5;
+                    padding: 6px 4px;
+                    color: #484848;
+                    font-size: 14px;
+                    line-height: 21px;
+                    font-weight: 500;
+                    width: fit-content;
+                  " th:text="${category}" id="category"></span>
+                        <span style="
+                    background-color: #f5f5f5;
+                    padding: 6px 4px;
+                    color: #484848;
+                    font-size: 14px;
+                    line-height: 21px;
+                    font-weight: 500;
+                    margin-left: 10px;
+                    width: fit-content;
+                  " id="current-day" th:text="${articleDay}"></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" style="padding-top: 20px">
+                        <h1 style="
+                    margin: 0;
+                    font-size: 28px;
+                    line-height: 42px;
+                    font-weight: 700;
+                    color: black;
+                  " id="article-title" th:text="${articleTitle}"></h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="1" style="padding-top: 20px">
+                            <span style="
+                      color: #a5a5a5;
+                      font-size: 16px;
+                      font-weight: 500;
+                      line-height: normal;
+                    ">작가</span>
+                        <span style="
+                      color: #484848;
+                      font-size: 16px;
+                      margin-left: 8px;
+                      font-weight: 700;
+                      line-height: normal;
+                    " id="writer-name" th:text="${writerName}"></span>
+                        <a th:href="${writerLink}" id="writer-link" target="_blank" style="vertical-align: middle">
+                            <img src="https://eehhqckznniu25210545.cdn.ntruss.com/images/2024-07-05/KDXS0LewYPPd4pmQ.png"
+                                 alt="next" />
+                        </a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2" style="
+                  padding: 20px 0;
+                  font-size: 16px;
+                  line-height: 25.44px;
+                  font-weight: 400;
+                " id="article-content" th:utext="${articleContent}"></td>
+                </tr>
             </table>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-      <table class="row row-3" align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff;">
-        <tbody>
-        <tr>
-          <td>
-            <table class="row-content stack" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #000000; background-color: #ffffff; width: 700px; margin: 0 auto;" width="700">
-              <tbody>
-              <tr>
-                <td class="column column-1" width="100%" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-weight: 400; text-align: left; padding-bottom: 5px; padding-top: 5px; vertical-align: top; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;">
-                  <table class="icons_block block-1" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
-                    <tr>
-                      <td class="pad" style="vertical-align: middle; color: #1e0e4b; font-family: 'Inter', sans-serif; font-size: 15px; padding-bottom: 5px; padding-top: 5px; text-align: center;">
-                        <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
-                          <tr>
-                            <td class="alignment" style="vertical-align: middle; text-align: center;"><!--[if vml]><table align="center" cellpadding="0" cellspacing="0" role="presentation" style="display:inline-block;padding-left:0px;padding-right:0px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;"><![endif]-->
-                              <!--[if !vml]><!-->
-                              <table class="icons-inner" style="mso-table-lspace: 0pt; mso-table-rspace: 0pt; display: inline-block; margin-right: -4px; padding-left: 0px; padding-right: 0px;" cellpadding="0" cellspacing="0" role="presentation"><!--<![endif]-->
-                              </table>
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              </tbody>
+        </td>
+    </tr>
+
+    <tr>
+        <td style="padding: 20px">
+            <table cellpadding="0" cellspacing="0" border="0" style="width: 100%">
+                <tr>
+                    <td colspan="2" align="center" style="padding-top: 20px">
+                        <a th:href="${problemLink}" target="_blank" style="
+                    display: block;
+                    width: 100%;
+                    padding: 17px 0;
+                    text-align: center;
+                    color: #ffffff;
+                    background-color: #264932;
+                    text-decoration: none;
+                    font-size: 14px;
+                    line-height: 21px;
+                    font-weight: 500;
+                    font-family: 'Pretendard Variable';
+                  ">문제 풀러 가기</a>
+                    </td>
+                </tr>
             </table>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-    </td>
-  </tr>
-  </tbody>
-</table><!-- End -->
+        </td>
+    </tr>
+
+    <tr>
+        <td style="padding: 30px 20px; text-align: center">
+            <table align="center">
+                <tr>
+                    <td style="padding: 0 6px">
+                        <a href="https://www.instagram.com/few.letter/" target="_blank">
+                            <img src="https://eehhqckznniu25210545.cdn.ntruss.com/images/2024-07-05/EqMtNZVbz44ZeKKc.png"
+                                 alt="instagram" />
+                        </a>
+                    </td>
+                    <td style="padding: 0 6px">
+                        <a href="https://www.fewletter.com" target="_blank">
+                            <img src="https://eehhqckznniu25210545.cdn.ntruss.com/images/2024-07-05/ppvejDQYz1MPbbBR.png"
+                                 alt="link" />
+                        </a>
+                    </td>
+                </tr>
+            </table>
+            <p style="
+              margin: 10px 0 0 0;
+              font-size: 14px;
+              line-height: 21px;
+              font-weight: 500;
+              color: #a5a5a5;
+            ">
+                <a th:href="${unsubscribeLink}" target="_blank"
+                   style="text-decoration: underline; color: #a5a5a5">수신거부</a>
+            </p>
+        </td>
+    </tr>
+</table>
 </body>
 
 </html>

--- a/email/src/test/kotlin/com/few/email/service/article/SendArticleEmailServiceTest.kt
+++ b/email/src/test/kotlin/com/few/email/service/article/SendArticleEmailServiceTest.kt
@@ -22,7 +22,7 @@ class SendArticleEmailServiceTest : SendAEmailTestSpec() {
         val args = SendArticleEmailArgs(
             to = "test@gmail.com",
             subject = "테스트" + LocalDateTime.now(),
-            articleContent = Content(
+            content = Content(
                 articleLink = URL("https://www.google.com"),
                 currentDate = LocalDate.now(),
                 category = "경제",

--- a/email/src/test/kotlin/com/few/email/service/article/SendArticleEmailServiceTest.kt
+++ b/email/src/test/kotlin/com/few/email/service/article/SendArticleEmailServiceTest.kt
@@ -3,6 +3,7 @@ package com.few.email.service.article
 import com.few.email.service.SendAEmailTestSpec
 import com.few.email.service.article.dto.Content
 import com.few.email.service.article.dto.SendArticleEmailArgs
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.net.URL
@@ -15,6 +16,7 @@ class SendArticleEmailServiceTest : SendAEmailTestSpec() {
     private lateinit var sendArticleEmailService: SendArticleEmailService
 
     @Test
+    @Disabled
     fun `아티클 이메일 전송 테스트`() {
         // given
         val args = SendArticleEmailArgs(

--- a/email/src/test/kotlin/com/few/email/service/article/SendArticleEmailServiceTest.kt
+++ b/email/src/test/kotlin/com/few/email/service/article/SendArticleEmailServiceTest.kt
@@ -1,9 +1,12 @@
 package com.few.email.service.article
 
 import com.few.email.service.SendAEmailTestSpec
+import com.few.email.service.article.dto.Content
 import com.few.email.service.article.dto.SendArticleEmailArgs
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.net.URL
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SendArticleEmailServiceTest : SendAEmailTestSpec() {
@@ -17,9 +20,19 @@ class SendArticleEmailServiceTest : SendAEmailTestSpec() {
         val args = SendArticleEmailArgs(
             to = "test@gmail.com",
             subject = "테스트" + LocalDateTime.now(),
-            articleContent = "테스트입니다.",
-            style = getStyle(),
-            template = "test"
+            articleContent = Content(
+                articleLink = URL("https://www.google.com"),
+                currentDate = LocalDate.now(),
+                category = "경제",
+                articleDay = 1,
+                articleTitle = "제목",
+                writerName = "작성자",
+                writerLink = URL("https://www.google.com"),
+                articleContent = "내용",
+                problemLink = URL("https://www.google.com"),
+                unsubscribeLink = URL("https://www.google.com")
+            ),
+            template = "article"
         )
 
         // when


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #131

💁‍♂️ PR 내용
----
- 이메일 구독 내용 채워서 구현

🙏 작업
----
- SendArticleEmailArgs 구체화
- BatchCategoryType, BatchMemberType 추가: data 의존성을 추가하는 것 보다 동일한 이넘을 만들고 javadocs로 관련 기록을 하는 것이 좋지 않을까 판다하여 추가
- 이메일 내용을 채우기 위한 조회 추가: 기존의 id로만 가지고 있던 것을 활용하여 이메일 내용에 필요한 정보 조회 추가 (CONTENT, TITLE, CATEGORY_CD, WRITER NAME, URL)

🙈 PR 참고 사항
----
- email 탬플릿 수정 사항 클라이언트에 전달 받아 추가해야함

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
