### PR TITLE
[Feat/#155] 아티클 아이디로 문제 조회하는 API 구현

### DIFF
--- a/api/src/main/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCase.kt
@@ -1,0 +1,21 @@
+package com.few.api.domain.problem.usecase
+
+import com.few.api.domain.problem.usecase.`in`.BrowseProblemsUseCaseIn
+import com.few.api.domain.problem.usecase.out.BrowseProblemsUseCaseOut
+import com.few.api.repo.dao.problem.ProblemDao
+import com.few.api.repo.dao.problem.query.SelectProblemsByArticleIdQuery
+import org.springframework.stereotype.Component
+
+@Component
+class BrowseProblemsUseCase(
+    private val problemDao: ProblemDao
+) {
+
+    fun execute(useCaseIn: BrowseProblemsUseCaseIn): BrowseProblemsUseCaseOut {
+        SelectProblemsByArticleIdQuery(useCaseIn.articleId).let { query: SelectProblemsByArticleIdQuery ->
+            problemDao.selectProblemsByArticleId(query) ?: throw IllegalArgumentException("cannot find problems by articleId: ${query.articleId}") // todo 에러 표준화
+        }.let {
+            return BrowseProblemsUseCaseOut(it.problemIds)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/problem/usecase/in/BrowseProblemsUseCaseIn.kt
+++ b/api/src/main/kotlin/com/few/api/domain/problem/usecase/in/BrowseProblemsUseCaseIn.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.problem.usecase.`in`
+
+data class BrowseProblemsUseCaseIn(
+    val articleId: Long
+)

--- a/api/src/main/kotlin/com/few/api/domain/problem/usecase/out/BrowseProblemsUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/problem/usecase/out/BrowseProblemsUseCaseOut.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.problem.usecase.out
+
+data class BrowseProblemsUseCaseOut(
+    val problemIds: List<Long>
+)

--- a/api/src/main/kotlin/com/few/api/web/controller/problem/ProblemController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/problem/ProblemController.kt
@@ -1,5 +1,6 @@
 package com.few.api.web.controller.problem
 
+import com.few.api.domain.problem.usecase.BrowseProblemsUseCase
 import com.few.api.web.controller.problem.request.CheckProblemBody
 import com.few.api.web.controller.problem.response.CheckProblemResponse
 import com.few.api.web.controller.problem.response.ProblemContents
@@ -8,8 +9,10 @@ import com.few.api.web.support.ApiResponse
 import com.few.api.web.support.ApiResponseGenerator
 import com.few.api.domain.problem.usecase.CheckProblemUseCase
 import com.few.api.domain.problem.usecase.ReadProblemUseCase
+import com.few.api.domain.problem.usecase.`in`.BrowseProblemsUseCaseIn
 import com.few.api.domain.problem.usecase.`in`.CheckProblemUseCaseIn
 import com.few.api.domain.problem.usecase.`in`.ReadProblemUseCaseIn
+import com.few.api.web.controller.problem.response.BrowseProblemsResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
@@ -22,9 +25,25 @@ import java.util.*
 @RestController
 @RequestMapping(value = ["/api/v1/problems"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ProblemController(
+    private val browseProblemsUseCase: BrowseProblemsUseCase,
     private val readProblemUseCase: ReadProblemUseCase,
     private val checkProblemUseCase: CheckProblemUseCase
 ) {
+
+    @GetMapping
+    fun browseProblems(@RequestParam(value = "articleId", required = false) articleId: Long?): ApiResponse<ApiResponse.SuccessBody<BrowseProblemsResponse>> {
+        articleId?.let { id ->
+            val useCaseOut = BrowseProblemsUseCaseIn(id).let { useCaseIn ->
+                browseProblemsUseCase.execute(useCaseIn)
+            }
+
+            val response = BrowseProblemsResponse(useCaseOut.problemIds)
+
+            return ApiResponseGenerator.success(response, HttpStatus.OK)
+        }
+
+        throw IllegalArgumentException("Invalid parameter")
+    }
 
     @GetMapping("/{problemId}")
     fun readProblem(

--- a/api/src/main/kotlin/com/few/api/web/controller/problem/response/BrowseProblemsResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/problem/response/BrowseProblemsResponse.kt
@@ -1,0 +1,5 @@
+package com.few.api.web.controller.problem.response
+
+data class BrowseProblemsResponse(
+    val problemIds: List<Long>
+)


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #155

💁‍♂️ PR 내용
----
- 아티클 아이디로 문제 조회하는 API 구현

🙏 작업
----
- 기존에 구현한 selectProblemsByArticleId를 활용하여 아티클 아이디로 문제를 조회하는 API 구현
- API URL이 적절한지 논의 필요

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
