### PR TITLE
[#199/Refactor] 이메일 전송시 중복되는 값 자료형 발견하여 수정

### DIFF
--- a/batch/src/main/kotlin/com/few/batch/service/article/dto/WorkBookSubscriberItem.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/dto/WorkBookSubscriberItem.kt
@@ -1,11 +1,11 @@
 package com.few.batch.service.article.dto
 
-fun List<WorkBookSubscriberItem>.toMemberIds(): List<Long> {
-    return this.map { it.memberId }
+fun List<WorkBookSubscriberItem>.toMemberIds(): Set<Long> {
+    return this.map { it.memberId }.toSet()
 }
 
-fun List<WorkBookSubscriberItem>.toTargetWorkBookIds(): List<Long> {
-    return this.map { it.targetWorkBookId }
+fun List<WorkBookSubscriberItem>.toTargetWorkBookIds(): Set<Long> {
+    return this.map { it.targetWorkBookId }.toSet()
 }
 
 /** key: 구독자들이 구독한 학습지 ID, value: 구독자들의 학습지 구독 진행률 */

--- a/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
@@ -129,6 +129,7 @@ class WorkBookSubscriberWriter(
             .and(articleIfoT.DELETED_AT.isNull)
             .fetchInto(ArticleContent::class.java)
 
+        // todo fix
         val memberSuccessRecords = memberIds.associateWith { true }.toMutableMap()
         val failRecords = mutableMapOf<String, ArrayList<Map<Long, String>>>()
         // todo check !! target is not null


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #199

💁‍♂️ PR 내용
----
- 이메일 전송시 중복되는 값 자료형 발견하여 수정

🙏 작업
----
- 이메일 전송시 중복되는 값 자료형 발견하여 수정 List -> Set
MemberId와 TargetWorkbookId의 자료형이 List여서 중복되는 값으로 조회하는 것을 확인했습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
