### PR TITLE
[#198/fix] in의 잘못된 사용으로 마지막 학습지를 받지 않은 구독자들도 구독을 해지하는 문제 해결

### DIFF
--- a/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
@@ -49,6 +49,11 @@ data class ArticleContent(
     val writerLink: URL
 )
 
+data class ReceiveLastDayMember(
+    val memberId: Long,
+    val targetWorkBookId: Long
+)
+
 fun List<ArticleContent>.peek(articleId: Long): ArticleContent {
     return this.find {
         it.id == articleId
@@ -190,9 +195,9 @@ class WorkBookSubscriberWriter(
         }.filter {
             (it.progress.toInt() + 1) == lastDayCol[it.targetWorkBookId]
         }.map {
-            it.memberId
+            ReceiveLastDayMember(it.memberId, it.targetWorkBookId)
         }.filter {
-            memberSuccessRecords[it] == true
+            memberSuccessRecords[it.memberId] == true
         }
 
         val successMemberIds = memberSuccessRecords.filter { it.value }.keys
@@ -204,12 +209,15 @@ class WorkBookSubscriberWriter(
             .execute()
 
         /** 마지막 학습지를 받은 구독자들은 구독을 해지한다.*/
-        dslContext.update(subscriptionT)
-            .set(subscriptionT.DELETED_AT, LocalDateTime.now())
-            .set(subscriptionT.UNSUBS_OPINION, "receive.all")
-            .where(subscriptionT.MEMBER_ID.`in`(receiveLastDayMembers))
-            .and(subscriptionT.TARGET_WORKBOOK_ID.`in`(targetWorkBookIds))
-            .execute()
+        // todo refactoring to batch update
+        for (receiveLastDayMember in receiveLastDayMembers) {
+            dslContext.update(subscriptionT)
+                .set(subscriptionT.DELETED_AT, LocalDateTime.now())
+                .set(subscriptionT.UNSUBS_OPINION, "receive.all")
+                .where(subscriptionT.MEMBER_ID.eq(receiveLastDayMember.memberId))
+                .and(subscriptionT.TARGET_WORKBOOK_ID.eq(receiveLastDayMember.targetWorkBookId))
+                .execute()
+        }
 
         return if (failRecords.isNotEmpty()) {
             mapOf("records" to memberSuccessRecords, "fail" to failRecords)


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #198 

💁‍♂️ PR 내용
----
-  in의 잘못된 사용으로 마지막 학습지를 받지 않은 구독자들도 구독을 해지하는 문제 해결

🙏 작업
----
-  in의 잘못된 사용으로 마지막 학습지를 받지 않은 구독자들도 구독을 해지하는 문제를 발견하고 수정했습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----
### in 사용 쿼리 로그
<img width="1139" alt="스크린샷 2024-07-13 오전 11 37 52" src="https://github.com/user-attachments/assets/793b214c-b52a-4245-ab17-6bfb708e362f">

### in 사용 쿼리 결과
![스크린샷 2024-07-13 오전 11 38 51](https://github.com/user-attachments/assets/f871e230-0224-4c84-a4e0-2991b940b38f)



🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
