### PR TITLE
[Test/#145] UseCase 단위 테스트 구현

### DIFF
--- a/api/src/test/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCaseTest.kt
@@ -24,14 +24,14 @@ class ReadArticleUseCaseTest : BehaviorSpec({
     lateinit var useCase: ReadArticleUseCase
     val useCaseIn = ReadArticleUseCaseIn(articleId = 1L)
 
-    given("아티클 조회 요청이 온 상황에서") {
-        beforeContainer {
-            articleDao = mockk<ArticleDao>()
-            readArticleWriterRecordService = mockk<ReadArticleWriterRecordService>()
-            browseArticleProblemsService = mockk<BrowseArticleProblemsService>()
-            useCase = ReadArticleUseCase(articleDao, readArticleWriterRecordService, browseArticleProblemsService)
-        }
+    beforeContainer {
+        articleDao = mockk<ArticleDao>()
+        readArticleWriterRecordService = mockk<ReadArticleWriterRecordService>()
+        browseArticleProblemsService = mockk<BrowseArticleProblemsService>()
+        useCase = ReadArticleUseCase(articleDao, readArticleWriterRecordService, browseArticleProblemsService)
+    }
 
+    given("아티클 조회 요청이 온 상황에서") {
         `when`("아티클과 작가가 존재할 경우") {
             val record = SelectArticleRecord(
                 articleId = 1L,

--- a/api/src/test/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCaseTest.kt
@@ -1,0 +1,75 @@
+package com.few.api.domain.article.usecase
+
+import com.few.api.domain.article.service.BrowseArticleProblemsService
+import com.few.api.domain.article.service.ReadArticleWriterRecordService
+import com.few.api.domain.article.service.dto.BrowseArticleProblemsOutDto
+import com.few.api.domain.article.service.dto.ReadWriterOutDto
+import com.few.api.domain.article.usecase.dto.ReadArticleUseCaseIn
+import com.few.api.repo.dao.article.ArticleDao
+import com.few.api.repo.dao.article.record.SelectArticleRecord
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import java.net.URL
+import java.time.LocalDateTime
+
+class ReadArticleUseCaseTest : BehaviorSpec({
+
+    lateinit var articleDao: ArticleDao
+    lateinit var readArticleWriterRecordService: ReadArticleWriterRecordService
+    lateinit var browseArticleProblemsService: BrowseArticleProblemsService
+    lateinit var useCase: ReadArticleUseCase
+    val useCaseIn = ReadArticleUseCaseIn(articleId = 1L)
+
+    given("아티클 조회 요청이 온 상황에서") {
+        beforeContainer {
+            articleDao = mockk<ArticleDao>()
+            readArticleWriterRecordService = mockk<ReadArticleWriterRecordService>()
+            browseArticleProblemsService = mockk<BrowseArticleProblemsService>()
+            useCase = ReadArticleUseCase(articleDao, readArticleWriterRecordService, browseArticleProblemsService)
+        }
+
+        `when`("아티클과 작가가 존재할 경우") {
+            val record = SelectArticleRecord(
+                articleId = 1L,
+                writerId = 1L,
+                mainImageURL = URL("https://jh-labs.tistory.com/"),
+                title = "title",
+                category = (10).toByte(),
+                content = "content",
+                createdAt = LocalDateTime.now()
+            )
+            val writerSvcOutDto = ReadWriterOutDto(
+                writerId = 1L,
+                name = "hunca",
+                url = URL("https://jh-labs.tistory.com/")
+            )
+            val probSvcOutDto = BrowseArticleProblemsOutDto(problemIds = listOf(1, 2, 3))
+
+            every { articleDao.selectArticleRecord(any()) } returns record
+            every { readArticleWriterRecordService.execute(any()) } returns writerSvcOutDto
+            every { browseArticleProblemsService.execute(any()) } returns probSvcOutDto
+
+            then("아티클이 정상 조회된다") {
+                useCase.execute(useCaseIn)
+
+                verify(exactly = 1) { articleDao.selectArticleRecord(any()) }
+                verify(exactly = 1) { readArticleWriterRecordService.execute(any()) }
+                verify(exactly = 1) { browseArticleProblemsService.execute(any()) }
+            }
+        }
+
+        `when`("존재하지 않는 아티클일 경우") {
+            every { articleDao.selectArticleRecord(any()) } returns null
+
+            then("예외가 발생한다") {
+                shouldThrow<Exception> { useCase.execute(useCaseIn) }
+
+                verify(exactly = 1) { articleDao.selectArticleRecord(any()) }
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCaseTest.kt
@@ -13,15 +13,14 @@ class BrowseProblemsUseCaseTest : BehaviorSpec({
 
     lateinit var problemDao: ProblemDao
     lateinit var useCase: BrowseProblemsUseCase
-    lateinit var useCaseIn: BrowseProblemsUseCaseIn
+    val useCaseIn = BrowseProblemsUseCaseIn(articleId = 1L)
+
+    beforeContainer {
+        problemDao = mockk<ProblemDao>()
+        useCase = BrowseProblemsUseCase(problemDao)
+    }
 
     given("특정 아티클에 대한") {
-        beforeContainer {
-            problemDao = mockk<ProblemDao>()
-            useCase = BrowseProblemsUseCase(problemDao)
-            useCaseIn = BrowseProblemsUseCaseIn(articleId = 1L)
-        }
-
         `when`("문제가 존재할 경우") {
             val problemIdsRecord = ProblemIdsRecord(listOf(1, 2, 3))
             every { problemDao.selectProblemsByArticleId(any()) } returns problemIdsRecord

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.few.api.domain.problem.usecase
+
+import com.few.api.domain.problem.usecase.dto.BrowseProblemsUseCaseIn
+import com.few.api.repo.dao.problem.ProblemDao
+import com.few.api.repo.dao.problem.record.ProblemIdsRecord
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class BrowseProblemsUseCaseTest {
+
+    val problemDao: ProblemDao = mockk<ProblemDao>()
+
+    val useCase = BrowseProblemsUseCase(problemDao)
+
+    @Test
+    fun `특정 아티클에 문제가 존재할 경우 문제번호가 정상적으로 조회된다`() {
+        // given
+        val useCaseIn = BrowseProblemsUseCaseIn(articleId = 1L)
+        val problemIdsRecord = ProblemIdsRecord(listOf(1, 2, 3))
+
+        every { problemDao.selectProblemsByArticleId(any()) } returns problemIdsRecord
+
+        // when
+        useCase.execute(useCaseIn)
+
+        // then
+        verify(exactly = 1) { problemDao.selectProblemsByArticleId(any()) }
+    }
+
+    @Test
+    fun `특정 아티클에 문제가 존재하지 않을 경우 예외가 발생한다`() {
+        // given
+        val useCaseIn = BrowseProblemsUseCaseIn(articleId = 1L)
+
+        every { problemDao.selectProblemsByArticleId(any()) } returns null
+
+        // when / then
+        Assertions.assertThrows(Exception::class.java) { useCase.execute(useCaseIn) }
+        verify(exactly = 1) { problemDao.selectProblemsByArticleId(any()) }
+    }
+}

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/CheckProblemUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/CheckProblemUseCaseTest.kt
@@ -17,14 +17,13 @@ class CheckProblemUseCaseTest : BehaviorSpec({
     lateinit var submitHistoryDao: SubmitHistoryDao
     lateinit var useCase: CheckProblemUseCase
 
+    beforeContainer {
+        problemDao = mockk<ProblemDao>()
+        submitHistoryDao = mockk<SubmitHistoryDao>()
+        useCase = CheckProblemUseCase(problemDao, submitHistoryDao)
+    }
+
     given("문제 정답 확인 요청이 온 상황에서") {
-
-        beforeContainer {
-            problemDao = mockk<ProblemDao>()
-            submitHistoryDao = mockk<SubmitHistoryDao>()
-            useCase = CheckProblemUseCase(problemDao, submitHistoryDao)
-        }
-
         `when`("제출 값과 문제 정답이 같을 경우") {
             val submissionVal = "1"
             val answer = submissionVal

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/CheckProblemUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/CheckProblemUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.few.api.domain.problem.usecase
+
+import com.few.api.domain.problem.usecase.dto.CheckProblemUseCaseIn
+import com.few.api.repo.dao.problem.ProblemDao
+import com.few.api.repo.dao.problem.SubmitHistoryDao
+import com.few.api.repo.dao.problem.record.SelectProblemAnswerRecord
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class CheckProblemUseCaseTest {
+
+    val problemDao: ProblemDao = mockk<ProblemDao>()
+
+    val submitHistoryDao: SubmitHistoryDao = mockk<SubmitHistoryDao>()
+
+    val useCase = CheckProblemUseCase(problemDao, submitHistoryDao)
+
+    @Test
+    fun `제출 값과 문제 정답이 같다`() {
+        // given
+        val submissionVal = "1"
+        val answer = submissionVal
+        val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = submissionVal)
+        val answerRecord = SelectProblemAnswerRecord(id = 1L, answer = answer, explanation = "해설입니다.")
+
+        every { problemDao.selectProblemAnswer(any()) } returns answerRecord
+        every { submitHistoryDao.insertSubmitHistory(any()) } returns 1L
+
+        // when
+        val useCaseOut = useCase.execute(useCaseIn)
+
+        // then
+        assert(useCaseOut.isSolved)
+        verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
+        verify(exactly = 1) { submitHistoryDao.insertSubmitHistory(any()) }
+    }
+
+    @Test
+    fun `제출 값과 문제 정답이 다르다`() {
+        // given
+        val submissionVal = "1"
+        val answer = "2"
+        val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = submissionVal)
+        val answerRecord = SelectProblemAnswerRecord(id = 1L, answer = answer, explanation = "해설입니다.")
+
+        every { problemDao.selectProblemAnswer(any()) } returns answerRecord
+        every { submitHistoryDao.insertSubmitHistory(any()) } returns 1L
+
+        // when
+        val useCaseOut = useCase.execute(useCaseIn)
+
+        // then
+        assert(!useCaseOut.isSolved)
+        verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
+        verify(exactly = 1) { submitHistoryDao.insertSubmitHistory(any()) }
+    }
+
+    @Test
+    fun `존재하지 않는 문제일 경우 예외가 발생한다`() {
+        // given
+        val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = "1")
+
+        every { problemDao.selectProblemAnswer(any()) } returns null
+
+        // when, then
+        Assertions.assertThrows(Exception::class.java) { useCase.execute(useCaseIn) }
+
+        verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
+    }
+}

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/CheckProblemUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/CheckProblemUseCaseTest.kt
@@ -4,73 +4,72 @@ import com.few.api.domain.problem.usecase.dto.CheckProblemUseCaseIn
 import com.few.api.repo.dao.problem.ProblemDao
 import com.few.api.repo.dao.problem.SubmitHistoryDao
 import com.few.api.repo.dao.problem.record.SelectProblemAnswerRecord
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(MockKExtension::class)
-class CheckProblemUseCaseTest {
+class CheckProblemUseCaseTest : BehaviorSpec({
 
-    val problemDao: ProblemDao = mockk<ProblemDao>()
+    lateinit var problemDao: ProblemDao
+    lateinit var submitHistoryDao: SubmitHistoryDao
+    lateinit var useCase: CheckProblemUseCase
 
-    val submitHistoryDao: SubmitHistoryDao = mockk<SubmitHistoryDao>()
+    given("문제 정답 확인 요청이 온 상황에서") {
 
-    val useCase = CheckProblemUseCase(problemDao, submitHistoryDao)
+        beforeContainer {
+            problemDao = mockk<ProblemDao>()
+            submitHistoryDao = mockk<SubmitHistoryDao>()
+            useCase = CheckProblemUseCase(problemDao, submitHistoryDao)
+        }
 
-    @Test
-    fun `제출 값과 문제 정답이 같다`() {
-        // given
-        val submissionVal = "1"
-        val answer = submissionVal
-        val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = submissionVal)
-        val answerRecord = SelectProblemAnswerRecord(id = 1L, answer = answer, explanation = "해설입니다.")
+        `when`("제출 값과 문제 정답이 같을 경우") {
+            val submissionVal = "1"
+            val answer = submissionVal
+            val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = submissionVal)
+            val answerRecord = SelectProblemAnswerRecord(id = 1L, answer = answer, explanation = "해설입니다.")
 
-        every { problemDao.selectProblemAnswer(any()) } returns answerRecord
-        every { submitHistoryDao.insertSubmitHistory(any()) } returns 1L
+            every { problemDao.selectProblemAnswer(any()) } returns answerRecord
+            every { submitHistoryDao.insertSubmitHistory(any()) } returns 1L
 
-        // when
-        val useCaseOut = useCase.execute(useCaseIn)
+            then("문제가 정답처리 된다") {
+                val useCaseOut = useCase.execute(useCaseIn)
 
-        // then
-        assert(useCaseOut.isSolved)
-        verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
-        verify(exactly = 1) { submitHistoryDao.insertSubmitHistory(any()) }
+                useCaseOut.isSolved shouldBe true
+                verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
+                verify(exactly = 1) { submitHistoryDao.insertSubmitHistory(any()) }
+            }
+        }
+
+        `when`("제출 값과 문제 정답이 다를 경우") {
+            val submissionVal = "1"
+            val answer = "2"
+            val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = submissionVal)
+            val answerRecord = SelectProblemAnswerRecord(id = 1L, answer = answer, explanation = "해설입니다.")
+
+            every { problemDao.selectProblemAnswer(any()) } returns answerRecord
+            every { submitHistoryDao.insertSubmitHistory(any()) } returns 1L
+
+            then("문제가 오답처리 된다") {
+                val useCaseOut = useCase.execute(useCaseIn)
+
+                useCaseOut.isSolved shouldBe false
+                verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
+                verify(exactly = 1) { submitHistoryDao.insertSubmitHistory(any()) }
+            }
+        }
+
+        `when`("존재하지 않는 문제일 경우") {
+            val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = "1")
+
+            every { problemDao.selectProblemAnswer(any()) } returns null
+
+            then("예외가 발생한다") {
+                shouldThrow<Exception> { useCase.execute(useCaseIn) }
+                verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
+            }
+        }
     }
-
-    @Test
-    fun `제출 값과 문제 정답이 다르다`() {
-        // given
-        val submissionVal = "1"
-        val answer = "2"
-        val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = submissionVal)
-        val answerRecord = SelectProblemAnswerRecord(id = 1L, answer = answer, explanation = "해설입니다.")
-
-        every { problemDao.selectProblemAnswer(any()) } returns answerRecord
-        every { submitHistoryDao.insertSubmitHistory(any()) } returns 1L
-
-        // when
-        val useCaseOut = useCase.execute(useCaseIn)
-
-        // then
-        assert(!useCaseOut.isSolved)
-        verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
-        verify(exactly = 1) { submitHistoryDao.insertSubmitHistory(any()) }
-    }
-
-    @Test
-    fun `존재하지 않는 문제일 경우 예외가 발생한다`() {
-        // given
-        val useCaseIn = CheckProblemUseCaseIn(problemId = 1L, sub = "1")
-
-        every { problemDao.selectProblemAnswer(any()) } returns null
-
-        // when, then
-        Assertions.assertThrows(Exception::class.java) { useCase.execute(useCaseIn) }
-
-        verify(exactly = 1) { problemDao.selectProblemAnswer(any()) }
-    }
-}
+})

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/ReadProblemUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/ReadProblemUseCaseTest.kt
@@ -17,16 +17,15 @@ class ReadProblemUseCaseTest : BehaviorSpec({
     lateinit var problemDao: ProblemDao
     lateinit var contentsJsonMapper: ContentsJsonMapper
     lateinit var useCase: ReadProblemUseCase
-    lateinit var useCaseIn: ReadProblemUseCaseIn
+    val useCaseIn = ReadProblemUseCaseIn(problemId = 1L)
+
+    beforeContainer {
+        problemDao = mockk<ProblemDao>()
+        contentsJsonMapper = mockk<ContentsJsonMapper>()
+        useCase = ReadProblemUseCase(problemDao, contentsJsonMapper)
+    }
 
     given("문제를 조회할 상황에서") {
-        beforeContainer {
-            problemDao = mockk<ProblemDao>()
-            contentsJsonMapper = mockk<ContentsJsonMapper>()
-            useCase = ReadProblemUseCase(problemDao, contentsJsonMapper)
-            useCaseIn = ReadProblemUseCaseIn(problemId = 1L)
-        }
-
         `when`("문제가 존재할 경우") {
             val problemRecord = SelectProblemRecord(id = 1L, title = "title", contents = "{}")
             val contents = Contents(

--- a/api/src/test/kotlin/com/few/api/domain/problem/usecase/ReadProblemUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/problem/usecase/ReadProblemUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.few.api.domain.problem.usecase
+
+import com.few.api.domain.problem.usecase.dto.ReadProblemUseCaseIn
+import com.few.api.repo.dao.problem.ProblemDao
+import com.few.api.repo.dao.problem.record.SelectProblemRecord
+import com.few.api.repo.dao.problem.support.Content
+import com.few.api.repo.dao.problem.support.Contents
+import com.few.api.repo.dao.problem.support.ContentsJsonMapper
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class ReadProblemUseCaseTest {
+
+    val problemDao: ProblemDao = mockk<ProblemDao>()
+
+    val contentsJsonMapper: ContentsJsonMapper = mockk<ContentsJsonMapper>()
+
+    val useCase = ReadProblemUseCase(problemDao, contentsJsonMapper)
+
+    @Test
+    fun `문제ID로 문제를 조회힌다`() {
+        // given
+        val useCaseIn = ReadProblemUseCaseIn(problemId = 1L)
+        val problemRecord = SelectProblemRecord(id = 1L, title = "title", contents = "{}")
+        val contents = Contents(
+            listOf(
+                Content(number = 1, content = "{}"),
+                Content(number = 2, content = "{}")
+            )
+        )
+
+        every { problemDao.selectProblemContents(any()) } returns problemRecord
+        every { contentsJsonMapper.toObject(any()) } returns contents
+
+        // when
+        useCase.execute(useCaseIn)
+
+        // then
+        verify(exactly = 1) { problemDao.selectProblemContents(any()) }
+        verify(exactly = 1) { contentsJsonMapper.toObject(any()) }
+    }
+
+    @Test
+    fun `문제가 존재하지 않을 경우 예외가 발생한다`() {
+        // given
+        val useCaseIn = ReadProblemUseCaseIn(problemId = 1L)
+
+        every { problemDao.selectProblemContents(any()) } returns null
+
+        // when, then
+        Assertions.assertThrows(Exception::class.java) { useCase.execute(useCaseIn) }
+
+        verify(exactly = 1) { problemDao.selectProblemContents(any()) }
+    }
+}

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
@@ -6,110 +6,112 @@ import com.few.api.domain.subscription.service.dto.MemberIdOutDto
 import com.few.api.domain.subscription.usecase.dto.SubscribeWorkbookUseCaseIn
 import com.few.api.repo.dao.subscription.SubscriptionDao
 import com.few.api.repo.dao.subscription.record.WorkbookSubscriptionStatus
-import io.mockk.*
-import io.mockk.junit5.MockKExtension
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.extension.ExtendWith
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.just
+import io.mockk.Runs
 import org.springframework.context.ApplicationEventPublisher
 
-@ExtendWith(MockKExtension::class)
-class SubscribeWorkbookUseCaseTest {
-    val subscriptionDao = mockk<SubscriptionDao>()
+class SubscribeWorkbookUseCaseTest : BehaviorSpec({
 
-    val memberService = mockk<MemberService>()
+    lateinit var subscriptionDao: SubscriptionDao
+    lateinit var memberService: MemberService
+    lateinit var applicationEventPublisher: ApplicationEventPublisher
+    lateinit var useCase: SubscribeWorkbookUseCase
 
-    val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+    given("구독 요청이 온 상황에서") {
 
-    val useCase = SubscribeWorkbookUseCase(subscriptionDao, memberService, applicationEventPublisher)
-
-    @Test
-    fun `subscriptionStatus가 null일 경우 신규 구독을 추가한다`() {
-        // given
-        val workbookId = 1L
-        val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
-        val serviceOutDto = MemberIdOutDto(memberId = 1L)
-        val event = WorkbookSubscriptionEvent(workbookId)
-
-        every { memberService.readMemberId(any()) } returns null
-        every { memberService.insertMember(any()) } returns serviceOutDto
-        every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns null
-        every { subscriptionDao.insertWorkbookSubscription(any()) } just Runs
-        every { applicationEventPublisher.publishEvent(event) } answers {
-            println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+        beforeContainer {
+            subscriptionDao = mockk<SubscriptionDao>()
+            memberService = mockk<MemberService>()
+            applicationEventPublisher = mockk<ApplicationEventPublisher>()
+            useCase = SubscribeWorkbookUseCase(subscriptionDao, memberService, applicationEventPublisher)
         }
 
-        // when
-        useCase.execute(useCaseIn)
+        `when`("subscriptionStatus가 null일 경우") {
+            val workbookId = 1L
+            val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
+            val serviceOutDto = MemberIdOutDto(memberId = 1L)
+            val event = WorkbookSubscriptionEvent(workbookId)
 
-        // then
-        verify(exactly = 1) { memberService.insertMember(any()) }
-        verify(exactly = 1) { subscriptionDao.insertWorkbookSubscription(any()) }
-        verify(exactly = 0) { subscriptionDao.countWorkbookMappedArticles(any()) }
-        verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
-        verify(exactly = 1) { applicationEventPublisher.publishEvent(event) }
-    }
+            every { memberService.readMemberId(any()) } returns null
+            every { memberService.insertMember(any()) } returns serviceOutDto
+            every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns null
+            every { subscriptionDao.insertWorkbookSubscription(any()) } just Runs
+            every { applicationEventPublisher.publishEvent(event) } answers {
+                println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+            }
 
-    @Test
-    fun `구독을 취소한 경우 재구독한다`() {
-        // given
-        val workbookId = 1L
-        val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
-        val day = 2 // 현재 유저가 구독 취소 전 마지막으로 읽은 day 값
-        val lastDay = 3 // 워크북 고유 정보 (워크북이 구성된 day 값)
-        val serviceOutDto = MemberIdOutDto(memberId = 1L)
-        val subscriptionStatusRecord = WorkbookSubscriptionStatus(workbookId = workbookId, isActiveSub = false, day)
-        val event = WorkbookSubscriptionEvent(workbookId)
+            then("신규 구독을 추가한다") {
+                useCase.execute(useCaseIn)
 
-        every { memberService.readMemberId(any()) } returns null
-        every { memberService.insertMember(any()) } returns serviceOutDto
-        every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns subscriptionStatusRecord
-        every { subscriptionDao.countWorkbookMappedArticles(any()) } returns lastDay
-        every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
-        every { applicationEventPublisher.publishEvent(event) } answers {
-            println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+                verify(exactly = 1) { memberService.insertMember(any()) }
+                verify(exactly = 1) { subscriptionDao.insertWorkbookSubscription(any()) }
+                verify(exactly = 0) { subscriptionDao.countWorkbookMappedArticles(any()) }
+                verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
+                verify(exactly = 1) { applicationEventPublisher.publishEvent(event) }
+            }
         }
 
-        // when
-        useCase.execute(useCaseIn)
+        `when`("구독을 취소한 경우") {
+            val workbookId = 1L
+            val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
+            val day = 2
+            val lastDay = 3
+            val serviceOutDto = MemberIdOutDto(memberId = 1L)
+            val subscriptionStatusRecord = WorkbookSubscriptionStatus(workbookId = workbookId, isActiveSub = false, day)
+            val event = WorkbookSubscriptionEvent(workbookId)
 
-        // then
-        verify(exactly = 1) { memberService.insertMember(any()) }
-        verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
-        verify(exactly = 1) { subscriptionDao.countWorkbookMappedArticles(any()) }
-        verify(exactly = 1) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
-        verify(exactly = 1) { applicationEventPublisher.publishEvent(event) }
-    }
+            every { memberService.readMemberId(any()) } returns null
+            every { memberService.insertMember(any()) } returns serviceOutDto
+            every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns subscriptionStatusRecord
+            every { subscriptionDao.countWorkbookMappedArticles(any()) } returns lastDay
+            every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
+            every { applicationEventPublisher.publishEvent(event) } answers {
+                println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+            }
 
-    @Test
-    fun `이미 구독하고 있을 경우 예외가 발생한다`() {
-        // given
-        val workbookId = 1L
-        val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
-        val day = 2 // 현재 유저가 구독 취소 전 마지막으로 읽은 day 값
-        val lastDay = 3 // 워크북 고유 정보 (워크북이 구성된 day 값)
-        val serviceOutDto = MemberIdOutDto(memberId = 1L)
-        val subscriptionStatusRecord = WorkbookSubscriptionStatus(workbookId = workbookId, isActiveSub = true, day)
-        val event = WorkbookSubscriptionEvent(workbookId)
+            then("재구독한다") {
+                useCase.execute(useCaseIn)
 
-        every { memberService.readMemberId(any()) } returns null
-        every { memberService.insertMember(any()) } returns serviceOutDto
-        every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns subscriptionStatusRecord
-        every { subscriptionDao.countWorkbookMappedArticles(any()) } returns lastDay
-        every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
-        every { applicationEventPublisher.publishEvent(event) } answers {
-            println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+                verify(exactly = 1) { memberService.insertMember(any()) }
+                verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
+                verify(exactly = 1) { subscriptionDao.countWorkbookMappedArticles(any()) }
+                verify(exactly = 1) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
+                verify(exactly = 1) { applicationEventPublisher.publishEvent(event) }
+            }
         }
 
-        // when
-        Assertions.assertThrows(Exception::class.java) { useCase.execute(useCaseIn) }
+        `when`("이미 구독하고 있을 경우") {
+            val workbookId = 1L
+            val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
+            val day = 2
+            val lastDay = 3
+            val serviceOutDto = MemberIdOutDto(memberId = 1L)
+            val subscriptionStatusRecord = WorkbookSubscriptionStatus(workbookId = workbookId, isActiveSub = true, day)
+            val event = WorkbookSubscriptionEvent(workbookId)
 
-        // then
-        verify(exactly = 1) { memberService.insertMember(any()) }
-        verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
-        verify(exactly = 0) { subscriptionDao.countWorkbookMappedArticles(any()) }
-        verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
-        verify(exactly = 0) { applicationEventPublisher.publishEvent(event) }
+            every { memberService.readMemberId(any()) } returns null
+            every { memberService.insertMember(any()) } returns serviceOutDto
+            every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns subscriptionStatusRecord
+            every { subscriptionDao.countWorkbookMappedArticles(any()) } returns lastDay
+            every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
+            every { applicationEventPublisher.publishEvent(event) } answers {
+                println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+            }
+
+            then("예외가 발생한다") {
+                shouldThrow<Exception> { useCase.execute(useCaseIn) }
+
+                verify(exactly = 1) { memberService.insertMember(any()) }
+                verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
+                verify(exactly = 0) { subscriptionDao.countWorkbookMappedArticles(any()) }
+                verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
+                verify(exactly = 0) { applicationEventPublisher.publishEvent(event) }
+            }
+        }
     }
-}
+})

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
@@ -1,0 +1,83 @@
+package com.few.api.domain.subscription.usecase
+
+import com.few.api.domain.subscription.event.dto.WorkbookSubscriptionEvent
+import com.few.api.domain.subscription.service.MemberService
+import com.few.api.domain.subscription.service.dto.MemberIdOutDto
+import com.few.api.domain.subscription.usecase.dto.SubscribeWorkbookUseCaseIn
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import com.few.api.repo.dao.subscription.record.WorkbookSubscriptionStatus
+import io.mockk.*
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.ApplicationEventPublisher
+
+@ExtendWith(MockKExtension::class)
+class SubscribeWorkbookUseCaseTest {
+    val subscriptionDao = mockk<SubscriptionDao>()
+
+    val memberService = mockk<MemberService>()
+
+    val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+
+    val useCase = SubscribeWorkbookUseCase(subscriptionDao, memberService, applicationEventPublisher)
+
+    @Test
+    fun `subscriptionStatus가 null일 경우 신규 구독을 추가한다`() {
+        // given
+        val workbookId = 1L
+        val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
+        val serviceOutDto = MemberIdOutDto(memberId = 1L)
+        val event = WorkbookSubscriptionEvent(workbookId)
+
+        every { memberService.readMemberId(any()) } returns null
+        every { memberService.insertMember(any()) } returns serviceOutDto
+        every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns null
+        every { subscriptionDao.insertWorkbookSubscription(any()) } just Runs
+        every { applicationEventPublisher.publishEvent(event) } answers {
+            println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+        }
+
+        // when
+        useCase.execute(useCaseIn)
+
+        // then
+        verify(exactly = 1) { memberService.insertMember(any()) }
+        verify(exactly = 1) { subscriptionDao.insertWorkbookSubscription(any()) }
+        verify(exactly = 0) { subscriptionDao.countWorkbookMappedArticles(any()) }
+        verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
+        verify(exactly = 1) { applicationEventPublisher.publishEvent(event) }
+    }
+
+    @Test
+    fun `구독을 취소한 경우 재구독한다`() {
+        // given
+        val workbookId = 1L
+        val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
+        val day = 2 // 현재 유저가 구독 취소 전 마지막으로 읽은 day 값
+        val lastDay = 3 // 워크북 고유 정보 (워크북이 구성된 day 값)
+        val serviceOutDto = MemberIdOutDto(memberId = 1L)
+        val subscriptionStatusRecord = WorkbookSubscriptionStatus(workbookId = workbookId, isActiveSub = false, day)
+        val event = WorkbookSubscriptionEvent(workbookId)
+
+        every { memberService.readMemberId(any()) } returns null
+        every { memberService.insertMember(any()) } returns serviceOutDto
+        every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns subscriptionStatusRecord
+        every { subscriptionDao.countWorkbookMappedArticles(any()) } returns lastDay
+        every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
+        every { applicationEventPublisher.publishEvent(event) } answers {
+            println("Mocking applicationEventPublisher.publishEvent(any()) was called")
+        }
+
+        // when
+        useCase.execute(useCaseIn)
+
+        // then
+        verify(exactly = 1) { memberService.insertMember(any()) }
+        verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
+        verify(exactly = 1) { subscriptionDao.countWorkbookMappedArticles(any()) }
+        verify(exactly = 1) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
+        verify(exactly = 1) { applicationEventPublisher.publishEvent(event) }
+    }
+}

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
@@ -21,19 +21,18 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
     lateinit var memberService: MemberService
     lateinit var applicationEventPublisher: ApplicationEventPublisher
     lateinit var useCase: SubscribeWorkbookUseCase
+    val workbookId = 1L
+    val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
+
+    beforeContainer {
+        subscriptionDao = mockk<SubscriptionDao>()
+        memberService = mockk<MemberService>()
+        applicationEventPublisher = mockk<ApplicationEventPublisher>()
+        useCase = SubscribeWorkbookUseCase(subscriptionDao, memberService, applicationEventPublisher)
+    }
 
     given("구독 요청이 온 상황에서") {
-
-        beforeContainer {
-            subscriptionDao = mockk<SubscriptionDao>()
-            memberService = mockk<MemberService>()
-            applicationEventPublisher = mockk<ApplicationEventPublisher>()
-            useCase = SubscribeWorkbookUseCase(subscriptionDao, memberService, applicationEventPublisher)
-        }
-
         `when`("subscriptionStatus가 null일 경우") {
-            val workbookId = 1L
-            val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
             val serviceOutDto = MemberIdOutDto(memberId = 1L)
             val event = WorkbookSubscriptionEvent(workbookId)
 
@@ -57,8 +56,6 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
         }
 
         `when`("구독을 취소한 경우") {
-            val workbookId = 1L
-            val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
             val day = 2
             val lastDay = 3
             val serviceOutDto = MemberIdOutDto(memberId = 1L)
@@ -86,8 +83,6 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
         }
 
         `when`("이미 구독하고 있을 경우") {
-            val workbookId = 1L
-            val useCaseIn = SubscribeWorkbookUseCaseIn(workbookId = workbookId, email = "test@test.com")
             val day = 2
             val lastDay = 3
             val serviceOutDto = MemberIdOutDto(memberId = 1L)

--- a/api/src/test/kotlin/com/few/api/domain/workbook/usecase/ReadWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/workbook/usecase/ReadWorkbookUseCaseTest.kt
@@ -1,0 +1,83 @@
+package com.few.api.domain.workbook.usecase
+
+import com.few.api.domain.workbook.service.WorkbookArticleService
+import com.few.api.domain.workbook.service.WorkbookMemberService
+import com.few.api.domain.workbook.service.dto.WorkBookArticleOutDto
+import com.few.api.domain.workbook.service.dto.WriterOutDto
+import com.few.api.domain.workbook.usecase.dto.ReadWorkbookUseCaseIn
+import com.few.api.repo.dao.workbook.WorkbookDao
+import com.few.api.repo.dao.workbook.record.SelectWorkBookRecord
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import java.net.URL
+import java.time.LocalDateTime
+
+class ReadWorkbookUseCaseTest : BehaviorSpec({
+    lateinit var workbookDao: WorkbookDao
+    lateinit var workbookArticleService: WorkbookArticleService
+    lateinit var workbookMemberService: WorkbookMemberService
+    lateinit var useCase: ReadWorkbookUseCase
+    val useCaseIn = ReadWorkbookUseCaseIn(workbookId = 1L)
+
+    given("워크북 조회 요청이 온 상황에서") {
+        beforeContainer {
+            workbookDao = mockk<WorkbookDao>()
+            workbookArticleService = mockk<WorkbookArticleService>()
+            workbookMemberService = mockk<WorkbookMemberService>()
+            useCase = ReadWorkbookUseCase(workbookDao, workbookArticleService, workbookMemberService)
+        }
+
+        `when`("워크북과 작가가 존재할 경우") {
+            every { workbookDao.selectWorkBook(any()) } returns SelectWorkBookRecord(
+                id = 1L,
+                title = "workbook title",
+                mainImageUrl = URL("https://jh-labs.tistory.com/"),
+                category = (10).toByte(),
+                description = "workbook description",
+                createdAt = LocalDateTime.now()
+            )
+            every { workbookArticleService.browseWorkbookArticles(any()) } returns listOf(
+                WorkBookArticleOutDto(
+                    articleId = 1L,
+                    writerId = 1L,
+                    mainImageURL = URL("https://jh-labs.tistory.com/"),
+                    title = "article title",
+                    category = (10).toByte(),
+                    content = "article description",
+                    createdAt = LocalDateTime.now()
+                )
+            )
+            every { workbookMemberService.browseWriterRecords(any()) } returns listOf(
+                WriterOutDto(
+                    writerId = 1L,
+                    name = "hunca",
+                    url = URL("https://jh-labs.tistory.com/")
+                )
+            )
+
+            then("워크북 정상 조회된다") {
+                useCase.execute(useCaseIn)
+
+                verify(exactly = 1) { workbookDao.selectWorkBook(any()) }
+                verify(exactly = 1) { workbookArticleService.browseWorkbookArticles(any()) }
+                verify(exactly = 1) { workbookMemberService.browseWriterRecords(any()) }
+            }
+        }
+
+        `when`("워크북이 존재하지 않을 경우") {
+            every { workbookDao.selectWorkBook(any()) } returns null
+
+            then("예외가 발생한다") {
+                shouldThrow<Exception> { useCase.execute(useCaseIn) }
+
+                verify(exactly = 1) { workbookDao.selectWorkBook(any()) }
+                verify(exactly = 0) { workbookArticleService.browseWorkbookArticles(any()) }
+                verify(exactly = 0) { workbookMemberService.browseWriterRecords(any()) }
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/few/api/domain/workbook/usecase/ReadWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/workbook/usecase/ReadWorkbookUseCaseTest.kt
@@ -23,14 +23,14 @@ class ReadWorkbookUseCaseTest : BehaviorSpec({
     lateinit var useCase: ReadWorkbookUseCase
     val useCaseIn = ReadWorkbookUseCaseIn(workbookId = 1L)
 
-    given("워크북 조회 요청이 온 상황에서") {
-        beforeContainer {
-            workbookDao = mockk<WorkbookDao>()
-            workbookArticleService = mockk<WorkbookArticleService>()
-            workbookMemberService = mockk<WorkbookMemberService>()
-            useCase = ReadWorkbookUseCase(workbookDao, workbookArticleService, workbookMemberService)
-        }
+    beforeContainer {
+        workbookDao = mockk<WorkbookDao>()
+        workbookArticleService = mockk<WorkbookArticleService>()
+        workbookMemberService = mockk<WorkbookMemberService>()
+        useCase = ReadWorkbookUseCase(workbookDao, workbookArticleService, workbookMemberService)
+    }
 
+    given("워크북 조회 요청이 온 상황에서") {
         `when`("워크북과 작가가 존재할 경우") {
             every { workbookDao.selectWorkBook(any()) } returns SelectWorkBookRecord(
                 id = 1L,


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #145 

💁‍♂️ PR 내용
----
제곧내

🙏 작업
----
제곧내

🙈 PR 참고 사항
----
- MockK 사용함
- [간단한 사용법 문서 바로가기](https://blog.kotlin-academy.com/mocking-is-not-rocket-science-expected-behavior-and-behavior-verification-3862dd0e0f03)
- UC 레벨에서 딱히 단위테스트 구현 필요성 있어보이는 부분이 `SubscribeWorkbookUseCase` 정도로 보입니다..
- kotest 기반으로 JUnit을 구동하기 위해 인텔리제이에서 kotest 플러그인 설치 필요

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
