### PR TITLE
[Feat/#238] 워크북 데이터 베이스 케시 설정

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
@@ -23,6 +23,7 @@ class LocalCacheConfig {
     companion object {
         const val LOCAL_CM = "localCacheManager"
         const val SELECT_ARTICLE_RECORD_CACHE = "selectArticleRecordCache"
+        const val SELECT_WORKBOOK_RECORD_CACHE = "selectWorkBookRecordCache"
     }
 
     @Bean(LOCAL_CM)
@@ -49,8 +50,11 @@ class LocalCacheConfig {
 
         val selectArticleRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
             Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
+        val selectWorkBookRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
+            Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
         runCatching {
             cacheManager.createCache(SELECT_ARTICLE_RECORD_CACHE, selectArticleRecordCacheConfig)
+            cacheManager.createCache(SELECT_WORKBOOK_RECORD_CACHE, selectWorkBookRecordCacheConfig)
         }.onFailure {
             log.error(it) { "Failed to create cache" }
         }

--- a/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
@@ -40,25 +40,36 @@ class LocalCacheConfig {
         )
         val cacheManager = EhcacheCachingProvider().cacheManager
 
-        val cacheConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        val cache10ConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(
             Any::class.java,
             Any::class.java,
             ResourcePoolsBuilder.newResourcePoolsBuilder()
-                .heap(50, EntryUnit.ENTRIES)
+                .heap(10, EntryUnit.ENTRIES)
+        )
+            .withService(cacheEventListenerConfigurationConfig)
+            .build()
+
+        val cache5ConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(
+            Any::class.java,
+            Any::class.java,
+            ResourcePoolsBuilder.newResourcePoolsBuilder()
+                .heap(5, EntryUnit.ENTRIES)
         )
             .withService(cacheEventListenerConfigurationConfig)
             .build()
 
         val selectArticleRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
-            Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
+            Eh107Configuration.fromEhcacheCacheConfiguration(cache10ConfigurationBuilder)
         val selectWorkBookRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
-            Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
-        val selectWritersCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
-            Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
+            Eh107Configuration.fromEhcacheCacheConfiguration(cache10ConfigurationBuilder)
+
+        val selectWriterCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
+            Eh107Configuration.fromEhcacheCacheConfiguration(cache5ConfigurationBuilder)
+
         runCatching {
             cacheManager.createCache(SELECT_ARTICLE_RECORD_CACHE, selectArticleRecordCacheConfig)
             cacheManager.createCache(SELECT_WORKBOOK_RECORD_CACHE, selectWorkBookRecordCacheConfig)
-            cacheManager.createCache(SELECT_WRITER_CACHE, selectWritersCacheConfig)
+            cacheManager.createCache(SELECT_WRITER_CACHE, selectWriterCacheConfig)
         }.onFailure {
             log.error(it) { "Failed to create cache" }
         }

--- a/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
@@ -40,7 +40,7 @@ class LocalCacheConfig {
         )
         val cacheManager = EhcacheCachingProvider().cacheManager
 
-        val cache10ConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        val cache10Configuration = CacheConfigurationBuilder.newCacheConfigurationBuilder(
             Any::class.java,
             Any::class.java,
             ResourcePoolsBuilder.newResourcePoolsBuilder()
@@ -49,7 +49,7 @@ class LocalCacheConfig {
             .withService(cacheEventListenerConfigurationConfig)
             .build()
 
-        val cache5ConfigurationBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(
+        val cache5Configuration = CacheConfigurationBuilder.newCacheConfigurationBuilder(
             Any::class.java,
             Any::class.java,
             ResourcePoolsBuilder.newResourcePoolsBuilder()
@@ -59,12 +59,12 @@ class LocalCacheConfig {
             .build()
 
         val selectArticleRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
-            Eh107Configuration.fromEhcacheCacheConfiguration(cache10ConfigurationBuilder)
+            Eh107Configuration.fromEhcacheCacheConfiguration(cache10Configuration)
         val selectWorkBookRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
-            Eh107Configuration.fromEhcacheCacheConfiguration(cache10ConfigurationBuilder)
+            Eh107Configuration.fromEhcacheCacheConfiguration(cache10Configuration)
 
         val selectWriterCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
-            Eh107Configuration.fromEhcacheCacheConfiguration(cache5ConfigurationBuilder)
+            Eh107Configuration.fromEhcacheCacheConfiguration(cache5Configuration)
 
         runCatching {
             cacheManager.createCache(SELECT_ARTICLE_RECORD_CACHE, selectArticleRecordCacheConfig)

--- a/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/config/LocalCacheConfig.kt
@@ -24,6 +24,7 @@ class LocalCacheConfig {
         const val LOCAL_CM = "localCacheManager"
         const val SELECT_ARTICLE_RECORD_CACHE = "selectArticleRecordCache"
         const val SELECT_WORKBOOK_RECORD_CACHE = "selectWorkBookRecordCache"
+        const val SELECT_WRITER_CACHE = "selectWritersCache"
     }
 
     @Bean(LOCAL_CM)
@@ -52,9 +53,12 @@ class LocalCacheConfig {
             Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
         val selectWorkBookRecordCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
             Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
+        val selectWritersCacheConfig: javax.cache.configuration.Configuration<Any, Any> =
+            Eh107Configuration.fromEhcacheCacheConfiguration(cacheConfigurationBuilder)
         runCatching {
             cacheManager.createCache(SELECT_ARTICLE_RECORD_CACHE, selectArticleRecordCacheConfig)
             cacheManager.createCache(SELECT_WORKBOOK_RECORD_CACHE, selectWorkBookRecordCacheConfig)
+            cacheManager.createCache(SELECT_WRITER_CACHE, selectWritersCacheConfig)
         }.onFailure {
             log.error(it) { "Failed to create cache" }
         }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberCacheManager.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberCacheManager.kt
@@ -1,0 +1,48 @@
+package com.few.api.repo.dao.member
+
+import com.few.api.repo.config.LocalCacheConfig.Companion.SELECT_WRITER_CACHE
+import com.few.api.repo.dao.member.record.WriterRecord
+import org.springframework.cache.CacheManager
+import org.springframework.stereotype.Service
+import javax.cache.Cache
+
+@Suppress("UNCHECKED_CAST")
+@Service
+class MemberCacheManager(
+    private val cacheManager: CacheManager,
+) {
+
+    private var selectWriterCache: Cache<Any, Any> = cacheManager.getCache(SELECT_WRITER_CACHE)?.nativeCache as Cache<Any, Any>
+
+    fun getAllWriterKeys(): List<Long> {
+        val keys = mutableListOf<Long>()
+        selectWriterCache.iterator().forEach {
+            keys.add(it.key as Long)
+        }
+        return keys
+    }
+
+    fun getAllWriterValues(): List<WriterRecord> {
+        val values = mutableListOf<WriterRecord>()
+        selectWriterCache.iterator().forEach {
+            values.add(it.value as WriterRecord)
+        }
+        return values
+    }
+
+    fun getAllWriterValues(keys: List<Long>): List<WriterRecord> {
+        val values = mutableListOf<WriterRecord>()
+        keys.forEach {
+            selectWriterCache.get(it)?.let { value ->
+                values.add(value as WriterRecord)
+            }
+        }
+        return values
+    }
+
+    fun addSelectWorkBookCache(records: List<WriterRecord>) {
+        records.forEach {
+            selectWriterCache.put(it.writerId, it)
+        }
+    }
+}

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberCacheManager.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberCacheManager.kt
@@ -14,14 +14,6 @@ class MemberCacheManager(
 
     private var selectWriterCache: Cache<Any, Any> = cacheManager.getCache(SELECT_WRITER_CACHE)?.nativeCache as Cache<Any, Any>
 
-    fun getAllWriterKeys(): List<Long> {
-        val keys = mutableListOf<Long>()
-        selectWriterCache.iterator().forEach {
-            keys.add(it.key as Long)
-        }
-        return keys
-    }
-
     fun getAllWriterValues(): List<WriterRecord> {
         val values = mutableListOf<WriterRecord>()
         selectWriterCache.iterator().forEach {

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
@@ -45,8 +45,8 @@ class MemberDao(
      */
     fun selectWriters(query: SelectWritersQuery): List<WriterRecord> {
         val cachedValues = cacheManager.getAllWriterValues().filter { it.writerId in query.writerIds }
-        val cachedId = cachedValues.map { it.writerId }
-        val notCachedId = query.writerIds.filter { it !in cachedId }
+        val cachedIdS = cachedValues.map { it.writerId }
+        val notCachedIds = query.writerIds.filter { it !in cachedIdS }
 
         val fetchedValue = dslContext.select(
             Member.MEMBER.ID.`as`(WriterRecord::writerId.name),
@@ -55,7 +55,7 @@ class MemberDao(
             DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(WriterRecord::url.name)
         )
             .from(Member.MEMBER)
-            .where(Member.MEMBER.ID.`in`(notCachedId))
+            .where(Member.MEMBER.ID.`in`(notCachedIds))
             .and(Member.MEMBER.TYPE_CD.eq(MemberType.WRITER.code))
             .and(Member.MEMBER.DELETED_AT.isNull)
             .orderBy(Member.MEMBER.ID.asc())

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
@@ -1,5 +1,7 @@
 package com.few.api.repo.dao.member
 
+import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
+import com.few.api.repo.config.LocalCacheConfig.Companion.SELECT_WRITER_CACHE
 import com.few.api.repo.dao.member.command.InsertMemberCommand
 import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
 import com.few.api.repo.dao.member.query.SelectWriterQuery
@@ -10,13 +12,16 @@ import com.few.data.common.code.MemberType
 import jooq.jooq_dsl.tables.Member
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Repository
 
 @Repository
 class MemberDao(
     private val dslContext: DSLContext,
+    private val cacheManager: MemberCacheManager,
 ) {
 
+    @Cacheable(key = "#query.writerId", cacheManager = LOCAL_CM, cacheNames = [SELECT_WRITER_CACHE])
     fun selectWriter(query: SelectWriterQuery): WriterRecord? {
         val writerId = query.writerId
 
@@ -32,18 +37,35 @@ class MemberDao(
             .fetchOneInto(WriterRecord::class.java)
     }
 
+    /**
+     * 작가 목록 조회 쿼리
+     * query의 writerIds에 해당하는 작가 목록을 조회한다.
+     * 이때 먼저 cache에 작가 정보가 있는지 확인하고 없는 경우에만 DB에서 조회한다.
+     * 조회 이후에는 cache에 저장한다.
+     */
     fun selectWriters(query: SelectWritersQuery): List<WriterRecord> {
-        return dslContext.select(
+        val notCachedId = cacheManager.getAllWriterKeys().let { keys ->
+            query.writerIds.filter {
+                it !in keys
+            }
+        }.distinct()
+
+        dslContext.select(
             Member.MEMBER.ID.`as`(WriterRecord::writerId.name),
-            DSL.jsonGetAttributeAsText(Member.MEMBER.DESCRIPTION, "name").`as`(WriterRecord::name.name),
+            DSL.jsonGetAttributeAsText(Member.MEMBER.DESCRIPTION, "name")
+                .`as`(WriterRecord::name.name),
             DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(WriterRecord::url.name)
         )
             .from(Member.MEMBER)
-            .where(Member.MEMBER.ID.`in`(query.writerIds))
+            .where(Member.MEMBER.ID.`in`(notCachedId))
             .and(Member.MEMBER.TYPE_CD.eq(MemberType.WRITER.code))
             .and(Member.MEMBER.DELETED_AT.isNull)
             .orderBy(Member.MEMBER.ID.asc())
-            .fetchInto(WriterRecord::class.java)
+            .fetchInto(WriterRecord::class.java).let {
+                cacheManager.addSelectWorkBookCache(it)
+            }
+
+        return cacheManager.getAllWriterValues(query.writerIds)
     }
 
     fun selectMemberByEmail(query: SelectMemberByEmailQuery): MemberIdRecord? {

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkBookCacheManager.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkBookCacheManager.kt
@@ -14,14 +14,6 @@ class WorkBookCacheManager(
 
     private var selectWorkBookCache: Cache<Any, Any> = cacheManager.getCache(SELECT_WORKBOOK_RECORD_CACHE)?.nativeCache as Cache<Any, Any>
 
-    fun getAllSelectWorkBookKeys(): List<Long> {
-        val keys = mutableListOf<Long>()
-        selectWorkBookCache.iterator().forEach {
-            keys.add(it.key as Long)
-        }
-        return keys
-    }
-
     fun getAllSelectWorkBookValues(): List<SelectWorkBookRecord> {
         val values = mutableListOf<SelectWorkBookRecord>()
         selectWorkBookCache.iterator().forEach {

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkBookCacheManager.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkBookCacheManager.kt
@@ -1,0 +1,32 @@
+package com.few.api.repo.dao.workbook
+
+import com.few.api.repo.config.LocalCacheConfig.Companion.SELECT_WORKBOOK_RECORD_CACHE
+import com.few.api.repo.dao.workbook.record.SelectWorkBookRecord
+import org.springframework.cache.CacheManager
+import org.springframework.stereotype.Service
+import javax.cache.Cache
+
+@Suppress("UNCHECKED_CAST")
+@Service
+class WorkBookCacheManager(
+    private val cacheManager: CacheManager,
+) {
+
+    private var selectWorkBookCache: Cache<Any, Any> = cacheManager.getCache(SELECT_WORKBOOK_RECORD_CACHE)?.nativeCache as Cache<Any, Any>
+
+    fun getAllSelectWorkBookKeys(): List<Long> {
+        val keys = mutableListOf<Long>()
+        selectWorkBookCache.iterator().forEach {
+            keys.add(it.key as Long)
+        }
+        return keys
+    }
+
+    fun getAllSelectWorkBookValues(): List<SelectWorkBookRecord> {
+        val values = mutableListOf<SelectWorkBookRecord>()
+        selectWorkBookCache.iterator().forEach {
+            values.add(it.value as SelectWorkBookRecord)
+        }
+        return values
+    }
+}

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
@@ -1,5 +1,7 @@
 package com.few.api.repo.dao.workbook
 
+import com.few.api.repo.config.LocalCacheConfig
+import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
 import com.few.api.repo.dao.workbook.command.MapWorkBookToArticleCommand
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
@@ -8,12 +10,14 @@ import com.few.data.common.code.CategoryType
 import jooq.jooq_dsl.tables.MappingWorkbookArticle
 import jooq.jooq_dsl.tables.Workbook
 import org.jooq.DSLContext
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Repository
 
 @Repository
 class WorkbookDao(
     private val dslContext: DSLContext,
 ) {
+    @Cacheable(key = "#query.id", cacheManager = LOCAL_CM, cacheNames = [LocalCacheConfig.SELECT_WORKBOOK_RECORD_CACHE])
     fun selectWorkBook(query: SelectWorkBookRecordQuery): SelectWorkBookRecord? {
         return dslContext.select(
             Workbook.WORKBOOK.ID.`as`(SelectWorkBookRecord::id.name),

--- a/api/src/main/kotlin/com/few/api/domain/article/handler/ArticleViewHisAsyncHandler.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/handler/ArticleViewHisAsyncHandler.kt
@@ -34,6 +34,6 @@ class ArticleViewHisAsyncHandler(
                 "Failed insertion article view history and upsertion article view count " +
                     "for articleId: $articleId and memberId: $memberId"
             }
-        }
+        }.getOrThrow()
     }
 }


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #238 

💁‍♂️ PR 내용
----
- 워크북 데이터 베이스 케시 설정

🙏 작업
----
- SELECT_WORKBOOK_RECORD_CACHE 추가
- SELECT_WRITER_CACHE 추가
- selectWorkBook 메서드 캐시 설정
- selectWriter 메서드, selectWriters 메서드 데이터 캐시 설정
- 캐싱된 데이터 활용을 위한 XXXCacheManager 구현

🙈 PR 참고 사항
----

📸 스크린샷
----
## selectWorkBook 캐시 확인

![스크린샷 2024-07-23 오후 9 25 10](https://github.com/user-attachments/assets/f5431d0f-4f03-4d3a-b93a-45d4c3936b15)

엔트리 사이즈 3으로 설정후 아이디 1 -> 2 -> 3 -> 4 -> 4 조회 결과

## selectWriter 메서드, selectWriters 메서드 캐시 확인

아티클 조회시 selectWriter 수행됨
워크북 조회시 selectWriters 수행됨

### 워크북 1에 포함된 아티클 조회
![스크린샷 2024-07-23 오후 10 10 22](https://github.com/user-attachments/assets/d70aa597-6891-47ec-b5dd-9332b53c9525)

selectWriter에서 캐시 저장

### 워크북 1 조회
![스크린샷 2024-07-23 오후 10 10 40](https://github.com/user-attachments/assets/d8d15075-7025-4d0b-9393-ed82d85587a3)

selectWriters에서 캐시에 저장된 값 사용

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
