### PR TITLE
[Test/#250] Article 목록조회(무한스크롤) Mock API 구현

### DIFF
--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticlesUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticlesUseCase.kt
@@ -1,0 +1,15 @@
+package com.few.api.domain.article.usecase
+
+import com.few.api.domain.article.usecase.dto.ReadArticlesUseCaseIn
+import com.few.api.domain.article.usecase.dto.ReadArticlesUseCaseOut
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ReadArticlesUseCase {
+
+    @Transactional(readOnly = true)
+    fun execute(useCaseIn: ReadArticlesUseCaseIn): ReadArticlesUseCaseOut {
+        return ReadArticlesUseCaseOut(emptyList()) // TODO: impl
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
@@ -12,7 +12,7 @@ data class ReadArticleUseCaseOut(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
-    val includedWorkbooks: List<WorkbookDetail>? = null,
+    val includedWorkbooks: List<WorkbookDetail> = emptyList(),
 )
 
 data class WriterDetail(

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
@@ -12,10 +12,16 @@ data class ReadArticleUseCaseOut(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
+    val includedWorkbooks: List<WorkbookDetail> = emptyList(),
 )
 
 data class WriterDetail(
     val id: Long,
     val name: String,
     val url: URL,
+)
+
+data class WorkbookDetail(
+    val id: Long,
+    val title: String,
 )

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
@@ -12,7 +12,7 @@ data class ReadArticleUseCaseOut(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
-    val includedWorkbooks: List<WorkbookDetail> = emptyList(),
+    val includedWorkbooks: List<WorkbookDetail>? = null,
 )
 
 data class WriterDetail(

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticlesUseCaseIn.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticlesUseCaseIn.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.article.usecase.dto
+
+data class ReadArticlesUseCaseIn(
+    val prevArticleId: Long,
+)

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticlesUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticlesUseCaseOut.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.article.usecase.dto
+
+data class ReadArticlesUseCaseOut(
+    val articles: List<ReadArticleUseCaseOut>,
+)

--- a/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
@@ -34,9 +34,22 @@ class ArticleController(
             readArticleUseCase.execute(useCaseIn)
         }
 
-        return ReadArticleResponse(useCaseOut).let {
-            ApiResponseGenerator.success(it, HttpStatus.OK)
-        }
+        val response = ReadArticleResponse(
+            id = useCaseOut.id,
+            title = useCaseOut.title,
+            writer = WriterInfo(
+                useCaseOut.writer.id,
+                useCaseOut.writer.name,
+                useCaseOut.writer.url
+            ),
+            content = useCaseOut.content,
+            problemIds = useCaseOut.problemIds,
+            category = useCaseOut.category,
+            createdAt = useCaseOut.createdAt,
+            views = useCaseOut.views
+        )
+
+        return ApiResponseGenerator.success(response, HttpStatus.OK)
     }
 
     @GetMapping

--- a/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
@@ -75,7 +75,7 @@ class ArticleController(
                 category = a.category,
                 createdAt = a.createdAt,
                 views = a.views,
-                includedWorkbooks = a.includedWorkbooks.map { w ->
+                includedWorkbooks = a.includedWorkbooks?.map { w ->
                     WorkbookInfo(
                         id = w.id,
                         title = w.title

--- a/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
@@ -75,7 +75,7 @@ class ArticleController(
                 category = a.category,
                 createdAt = a.createdAt,
                 views = a.views,
-                includedWorkbooks = a.includedWorkbooks?.map { w ->
+                includedWorkbooks = a.includedWorkbooks.map { w ->
                     WorkbookInfo(
                         id = w.id,
                         title = w.title

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
@@ -13,6 +13,7 @@ data class ReadArticleResponse(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
+    val includedWorkbooks: List<WorkbookInfo>,
 ) {
     constructor(
         useCaseOut: ReadArticleUseCaseOut,
@@ -28,7 +29,8 @@ data class ReadArticleResponse(
         problemIds = useCaseOut.problemIds,
         category = useCaseOut.category,
         createdAt = useCaseOut.createdAt,
-        views = useCaseOut.views
+        views = useCaseOut.views,
+        includedWorkbooks = emptyList()
     )
 }
 
@@ -36,4 +38,9 @@ data class WriterInfo(
     val id: Long,
     val name: String,
     val url: URL,
+)
+
+data class WorkbookInfo(
+    val id: Long,
+    val title: String,
 )

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
@@ -1,6 +1,5 @@
 package com.few.api.web.controller.article.response
 
-import com.few.api.domain.article.usecase.dto.ReadArticleUseCaseOut
 import java.net.URL
 import java.time.LocalDateTime
 
@@ -13,26 +12,8 @@ data class ReadArticleResponse(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
-    val includedWorkbooks: List<WorkbookInfo>,
-) {
-    constructor(
-        useCaseOut: ReadArticleUseCaseOut,
-    ) : this(
-        id = useCaseOut.id,
-        writer = WriterInfo(
-            id = useCaseOut.writer.id,
-            name = useCaseOut.writer.name,
-            url = useCaseOut.writer.url
-        ),
-        title = useCaseOut.title,
-        content = useCaseOut.content,
-        problemIds = useCaseOut.problemIds,
-        category = useCaseOut.category,
-        createdAt = useCaseOut.createdAt,
-        views = useCaseOut.views,
-        includedWorkbooks = emptyList()
-    )
-}
+    val includedWorkbooks: List<WorkbookInfo> = emptyList(),
+)
 
 data class WriterInfo(
     val id: Long,

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
@@ -12,7 +12,7 @@ data class ReadArticleResponse(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
-    val includedWorkbooks: List<WorkbookInfo>? = null,
+    val includedWorkbooks: List<WorkbookInfo> = emptyList(),
 )
 
 data class WriterInfo(

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
@@ -12,7 +12,7 @@ data class ReadArticleResponse(
     val category: String,
     val createdAt: LocalDateTime,
     val views: Long,
-    val includedWorkbooks: List<WorkbookInfo> = emptyList(),
+    val includedWorkbooks: List<WorkbookInfo>? = null,
 )
 
 data class WriterInfo(

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticlesResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticlesResponse.kt
@@ -1,0 +1,6 @@
+package com.few.api.web.controller.article.response
+
+data class ReadArticlesResponse(
+    val articles: List<ReadArticleResponse>,
+    val isLast: Boolean,
+)

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -125,7 +125,9 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.createdAt")
                                             .fieldWithString("아티클 생성일"),
                                         PayloadDocumentation.fieldWithPath("data.views")
-                                            .fieldWithNumber("아티클 조회수")
+                                            .fieldWithNumber("아티클 조회수"),
+                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
+                                            .fieldWithNumber("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
                                     )
                                 )
                             ).build()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -128,9 +128,9 @@ class ArticleControllerTest : ControllerTestSpec() {
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
                                             .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)"),
-                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks.id")
+                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks[].id")
                                             .fieldWithNumber("아티클이 포함된 학습지 정보(학습지ID)(해당 API에서 사용되지 않음)"),
-                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks.title")
+                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks[].title")
                                             .fieldWithString("아티클이 포함된 학습지 정보(학습지 제목)(해당 API에서 사용되지 않음)")
                                     )
                                 )
@@ -193,7 +193,9 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data")
                                             .fieldWithObject("data"),
                                         PayloadDocumentation.fieldWithPath("data.isLast")
-                                            .fieldWithNumber("마지막 스크롤 유무"),
+                                            .fieldWithBoolean("마지막 스크롤 유무"),
+                                        PayloadDocumentation.fieldWithPath("data.articles")
+                                            .fieldWithArray("아티클 목록"),
                                         PayloadDocumentation.fieldWithPath("data.articles.id")
                                             .fieldWithNumber("아티클 Id"),
                                         PayloadDocumentation.fieldWithPath("data.articles.writer")
@@ -218,9 +220,9 @@ class ArticleControllerTest : ControllerTestSpec() {
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
                                             .fieldWithArray("아티클이 포함된 학습지 정보"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks.id")
+                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks[].id")
                                             .fieldWithNumber("아티클이 포함된 학습지 정보(학습지ID)"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks.title")
+                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks[].title")
                                             .fieldWithString("아티클이 포함된 학습지 정보(학습지 제목)")
                                     )
                                 )

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -137,12 +137,12 @@ class ArticleControllerTest : ControllerTestSpec() {
     }
 
     @Test
-    @DisplayName("[GET] /api/v1/articles?prevArticleId={prevArticleId}}")
+    @DisplayName("[GET] /api/v1/articles?prevArticleId={prevArticleId}")
     fun readArticles() {
         // given
         val api = "ReadArticles"
         val uri = UriComponentsBuilder.newInstance()
-            .path("$BASE_URL}")
+            .path("$BASE_URL")
             .queryParam("prevArticleId", 1L)
             .build()
             .toUriString()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -129,9 +129,9 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
                                             .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks.id")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지ID)(해당 API에서 사용되지 않음)"),
+                                            .fieldWithNumber("아티클이 포함된 학습지 정보(학습지ID)(해당 API에서 사용되지 않음)"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks.title")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지 제목)(해당 API에서 사용되지 않음)")
+                                            .fieldWithString("아티클이 포함된 학습지 정보(학습지 제목)(해당 API에서 사용되지 않음)")
                                     )
                                 )
                             ).build()
@@ -219,9 +219,9 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
                                             .fieldWithArray("아티클이 포함된 학습지 정보"),
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks.id")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지ID)"),
+                                            .fieldWithNumber("아티클이 포함된 학습지 정보(학습지ID)"),
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks.title")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지 제목)")
+                                            .fieldWithString("아티클이 포함된 학습지 정보(학습지 제목)")
                                     )
                                 )
                             ).build()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -127,7 +127,7 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
-                                            .fieldWithObject("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
                                     )
                                 )
                             ).build()
@@ -213,7 +213,7 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.articles.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
-                                            .fieldWithObject("아티클이 포함된 학습지 정보")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보")
                                     )
                                 )
                             ).build()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -127,7 +127,11 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)"),
+                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks.id")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지ID)(해당 API에서 사용되지 않음)"),
+                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks.title")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지 제목)(해당 API에서 사용되지 않음)")
                                     )
                                 )
                             ).build()
@@ -213,7 +217,11 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.articles.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks.id")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지ID)"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks.title")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(학습지 제목)")
                                     )
                                 )
                             ).build()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -5,10 +5,9 @@ import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.epages.restdocs.apispec.ResourceSnippetParameters
 import com.epages.restdocs.apispec.Schema
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.few.api.domain.article.usecase.dto.ReadArticleUseCaseIn
-import com.few.api.domain.article.usecase.dto.ReadArticleUseCaseOut
-import com.few.api.domain.article.usecase.dto.WriterDetail
 import com.few.api.domain.article.usecase.ReadArticleUseCase
+import com.few.api.domain.article.usecase.ReadArticlesUseCase
+import com.few.api.domain.article.usecase.dto.*
 import com.few.api.web.controller.ControllerTestSpec
 import com.few.api.web.controller.description.Description
 import com.few.api.web.controller.helper.*
@@ -42,6 +41,9 @@ class ArticleControllerTest : ControllerTestSpec() {
 
     @MockBean
     private lateinit var readArticleUseCase: ReadArticleUseCase
+
+    @MockBean
+    private lateinit var readArticlesUseCase: ReadArticlesUseCase
 
     companion object {
         private val BASE_URL = "/api/v1/articles"
@@ -96,7 +98,7 @@ class ArticleControllerTest : ControllerTestSpec() {
                         ResourceSnippetParameters.builder().description("아티클 Id로 아티클 조회")
                             .summary(api.toIdentifier()).privateResource(false).deprecated(false)
                             .tag(TAG).requestSchema(Schema.schema(api.toRequestSchema()))
-                            .pathParameters(parameterWithName("articleId").description("학습지 Id"))
+                            .pathParameters(parameterWithName("articleId").description("아티클 Id"))
                             .responseSchema(Schema.schema(api.toResponseSchema())).responseFields(
                                 *Description.describe(
                                     arrayOf(
@@ -124,6 +126,92 @@ class ArticleControllerTest : ControllerTestSpec() {
                                             .fieldWithString("아티클 생성일"),
                                         PayloadDocumentation.fieldWithPath("data.views")
                                             .fieldWithNumber("아티클 조회수")
+                                    )
+                                )
+                            ).build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("[GET] /api/v1/articles?prevArticleId={prevArticleId}}")
+    fun readArticles() {
+        // given
+        val api = "ReadArticles"
+        val uri = UriComponentsBuilder.newInstance()
+            .path("$BASE_URL}")
+            .queryParam("prevArticleId", 1L)
+            .build()
+            .toUriString()
+        // set usecase mock
+        val prevArticleId = 1L
+        `when`(readArticlesUseCase.execute(ReadArticlesUseCaseIn(prevArticleId))).thenReturn(
+            ReadArticlesUseCaseOut(
+                listOf(
+                    ReadArticleUseCaseOut(
+                        id = 1L,
+                        writer = WriterDetail(
+                            id = 1L,
+                            name = "안나포",
+                            url = URL("http://localhost:8080/api/v1/writers/1")
+                        ),
+                        title = "ETF(상장 지수 펀드)란? 모르면 손해라고?",
+                        content = CategoryType.fromCode(0)!!.name,
+                        problemIds = listOf(1L, 2L, 3L),
+                        category = "경제",
+                        createdAt = LocalDateTime.now(),
+                        views = 1L,
+                        includedWorkbooks = listOf(
+                            WorkbookDetail(1L, "사소한 것들의 역사"),
+                            WorkbookDetail(2L, "인모스트 경제레터")
+                        )
+                    )
+                )
+            )
+        )
+
+        // when
+        this.webTestClient.get().uri(uri).accept(MediaType.APPLICATION_JSON)
+            .exchange().expectStatus().isOk().expectBody().consumeWith(
+                WebTestClientRestDocumentation.document(
+                    api.toIdentifier(),
+                    ResourceDocumentation.resource(
+                        ResourceSnippetParameters.builder().description("아티 목록 10개씩 조회(조회수 기반 정렬)")
+                            .summary(api.toIdentifier()).privateResource(false).deprecated(false)
+                            .tag(TAG).requestSchema(Schema.schema(api.toRequestSchema()))
+                            .queryParameters(parameterWithName("prevArticleId").description("이전까지 조회한 아티클 Id"))
+                            .responseSchema(Schema.schema(api.toResponseSchema())).responseFields(
+                                *Description.describe(
+                                    arrayOf(
+                                        PayloadDocumentation.fieldWithPath("data")
+                                            .fieldWithObject("data"),
+                                        PayloadDocumentation.fieldWithPath("data.isLast")
+                                            .fieldWithNumber("마지막 스크롤 유무"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.id")
+                                            .fieldWithNumber("아티클 Id"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.writer")
+                                            .fieldWithObject("아티클 작가"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.writer.id")
+                                            .fieldWithNumber("아티클 작가 Id"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.writer.name")
+                                            .fieldWithString("아티클 작가 이름"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.writer.url")
+                                            .fieldWithString("아티클 작가 링크"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.title")
+                                            .fieldWithString("아티클 제목"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.content")
+                                            .fieldWithString("아티클 내용"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.problemIds")
+                                            .fieldWithArray("아티클 문제 목록"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.category")
+                                            .fieldWithString("아티클 카테고리"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.createdAt")
+                                            .fieldWithString("아티클 생성일"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.views")
+                                            .fieldWithNumber("아티클 조회수"),
+                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
+                                            .fieldWithNumber("아티클이 포함된 학습지 정보")
                                     )
                                 )
                             ).build()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -127,7 +127,7 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
-                                            .fieldWithNumber("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
+                                            .fieldWithObject("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
                                     )
                                 )
                             ).build()
@@ -213,7 +213,7 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.articles.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
-                                            .fieldWithNumber("아티클이 포함된 학습지 정보")
+                                            .fieldWithObject("아티클이 포함된 학습지 정보")
                                     )
                                 )
                             ).build()

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -196,33 +196,33 @@ class ArticleControllerTest : ControllerTestSpec() {
                                             .fieldWithBoolean("마지막 스크롤 유무"),
                                         PayloadDocumentation.fieldWithPath("data.articles")
                                             .fieldWithArray("아티클 목록"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.id")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].id")
                                             .fieldWithNumber("아티클 Id"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.writer")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].writer")
                                             .fieldWithObject("아티클 작가"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.writer.id")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].writer.id")
                                             .fieldWithNumber("아티클 작가 Id"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.writer.name")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].writer.name")
                                             .fieldWithString("아티클 작가 이름"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.writer.url")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].writer.url")
                                             .fieldWithString("아티클 작가 링크"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.title")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].title")
                                             .fieldWithString("아티클 제목"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.content")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].content")
                                             .fieldWithString("아티클 내용"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.problemIds")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].problemIds")
                                             .fieldWithArray("아티클 문제 목록"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.category")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].category")
                                             .fieldWithString("아티클 카테고리"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.createdAt")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].createdAt")
                                             .fieldWithString("아티클 생성일"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.views")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].views")
                                             .fieldWithNumber("아티클 조회수"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].includedWorkbooks")
                                             .fieldWithArray("아티클이 포함된 학습지 정보"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks[].id")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].includedWorkbooks[].id")
                                             .fieldWithNumber("아티클이 포함된 학습지 정보(학습지ID)"),
-                                        PayloadDocumentation.fieldWithPath("data.articles.includedWorkbooks[].title")
+                                        PayloadDocumentation.fieldWithPath("data.articles[].includedWorkbooks[].title")
                                             .fieldWithString("아티클이 포함된 학습지 정보(학습지 제목)")
                                     )
                                 )

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -127,11 +127,7 @@ class ArticleControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.views")
                                             .fieldWithNumber("아티클 조회수"),
                                         PayloadDocumentation.fieldWithPath("data.includedWorkbooks")
-                                            .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)"),
-                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks[].id")
-                                            .fieldWithNumber("아티클이 포함된 학습지 정보(학습지ID)(해당 API에서 사용되지 않음)"),
-                                        PayloadDocumentation.fieldWithPath("data.includedWorkbooks[].title")
-                                            .fieldWithString("아티클이 포함된 학습지 정보(학습지 제목)(해당 API에서 사용되지 않음)")
+                                            .fieldWithArray("아티클이 포함된 학습지 정보(해당 API에서 사용되지 않음)")
                                     )
                                 )
                             ).build()


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #250 

💁‍♂️ PR 내용
----
- 아티클 목록 조회 [API명세](https://github.com/YAPP-Github/24th-Web-Team-1-BE/wiki/%EC%95%84%ED%8B%B0%ED%81%B4_%EB%AA%A9%EB%A1%9D_%EC%A1%B0%ED%9A%8C) Mock API 구현
- "/api/v1/articles? prevArticleId={prevArticleId}"
    - `prevArticleId`: 이전 스크롤(요청)에서 읽어간 마지막 아티클 ID

🙏 작업
----

🙈 PR 참고 사항
----
- Swagger HUB를 통해 호출 가능한 Mock API 입니다

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
