### PR TITLE
[Feat/#240] 메인 워크북 API 구현 - 워크북 API 

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/query/BrowseWorkbookWritersQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/query/BrowseWorkbookWritersQuery.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.member.query
+
+data class BrowseWorkbookWritersQuery(
+    val workbookIds: List<Long>,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/WriterRecordMappedWorkbook.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/WriterRecordMappedWorkbook.kt
@@ -1,0 +1,10 @@
+package com.few.api.repo.dao.member.record
+
+import java.net.URL
+
+data class WriterRecordMappedWorkbook(
+    val workbookId: Long,
+    val writerId: Long,
+    val name: String,
+    val url: URL,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
@@ -4,13 +4,18 @@ import com.few.api.repo.config.LocalCacheConfig
 import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
 import com.few.api.repo.dao.workbook.command.MapWorkBookToArticleCommand
+import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import com.few.api.repo.dao.workbook.record.SelectWorkBookRecord
+import com.few.api.repo.dao.workbook.record.SelectWorkBookRecordWithSubscriptionCount
 import com.few.data.common.code.CategoryType
 import jooq.jooq_dsl.tables.MappingWorkbookArticle
+import jooq.jooq_dsl.tables.Subscription
 import jooq.jooq_dsl.tables.Workbook
+import org.jooq.Condition
 import org.jooq.DSLContext
 import org.springframework.cache.annotation.Cacheable
+import org.jooq.impl.DSL
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -56,5 +61,69 @@ class WorkbookDao(
             .set(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.ARTICLE_ID, command.articleId)
             .set(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DAY_COL, command.dayCol)
             .execute()
+    }
+
+    /**
+     * category에 따라서 조회된 구독자 수가 포함된 Workbook 목록을 반환한다.
+     * 정렬 순서는 구독자 수가 많은 순서로, 구독자 수가 같다면 생성일자가 최신인 순서로 반환한다.
+     */
+    fun browseWorkBookWithSubscriptionCount(query: BrowseWorkBookQueryWithSubscriptionCount): List<SelectWorkBookRecordWithSubscriptionCount> {
+        return browseWorkBookQuery(query)
+            .fetchInto(SelectWorkBookRecordWithSubscriptionCount::class.java)
+    }
+
+    fun browseWorkBookQuery(query: BrowseWorkBookQueryWithSubscriptionCount) =
+        dslContext.select(
+            Workbook.WORKBOOK.ID.`as`(SelectWorkBookRecordWithSubscriptionCount::id.name),
+            Workbook.WORKBOOK.TITLE.`as`(SelectWorkBookRecordWithSubscriptionCount::title.name),
+            Workbook.WORKBOOK.MAIN_IMAGE_URL.`as`(SelectWorkBookRecordWithSubscriptionCount::mainImageUrl.name),
+            Workbook.WORKBOOK.CATEGORY_CD.`as`(SelectWorkBookRecordWithSubscriptionCount::category.name),
+            Workbook.WORKBOOK.DESCRIPTION.`as`(SelectWorkBookRecordWithSubscriptionCount::description.name),
+            Workbook.WORKBOOK.CREATED_AT.`as`(SelectWorkBookRecordWithSubscriptionCount::createdAt.name),
+            /** 구독자 수가 없다면 0으로 반환한다. */
+            DSL.coalesce(
+                DSL.field("subscription_count_table.subscription_count", Long::class.java),
+                0
+            ).`as`(SelectWorkBookRecordWithSubscriptionCount::subscriptionCount.name)
+        )
+            .from(Workbook.WORKBOOK)
+            /** 구독자가 없는 Workbook도 조회하기 위해 LEFT JOIN을 사용한다. */
+            .leftJoin(
+                /** Subscription 테이블을 이용하여 구독자 수를 조회한다. */
+                dslContext.select(
+                    Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID.`as`(Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID.name),
+                    DSL.count(Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID)
+                        .`as`("subscription_count")
+                )
+                    .from(Subscription.SUBSCRIPTION)
+                    .where(Subscription.SUBSCRIPTION.DELETED_AT.isNull)
+                    .groupBy(Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID)
+                    .asTable("subscription_count_table")
+            )
+            .on(
+                Workbook.WORKBOOK.ID.eq(
+                    DSL.field(
+                        "subscription_count_table.${Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID.name}",
+                        Long::class.java
+                    )
+                )
+            )
+            .where(browseWorkBookCategoryCondition(query))
+            .and(Workbook.WORKBOOK.DELETED_AT.isNull)
+            /** 구독자 수가 많은 순서로, 구독자 수가 같다면 생성일자가 최신인 순서로 정렬한다. */
+            .orderBy(
+                DSL.field("subscription_count_table.subscription_count", Long::class.java).desc(),
+                Workbook.WORKBOOK.CREATED_AT.desc()
+            )
+            .query
+
+    /**
+     * category에 따라서 조건을 생성한다.
+     */
+    private fun browseWorkBookCategoryCondition(query: BrowseWorkBookQueryWithSubscriptionCount): Condition {
+        return when (query.category) {
+            (-1).toByte() -> DSL.noCondition()
+            else -> Workbook.WORKBOOK.CATEGORY_CD.eq(query.category)
+        }
     }
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/query/BrowseWorkBookQueryWithSubscriptionCount.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/query/BrowseWorkBookQueryWithSubscriptionCount.kt
@@ -1,0 +1,8 @@
+package com.few.api.repo.dao.workbook.query
+
+data class BrowseWorkBookQueryWithSubscriptionCount(
+    /**
+     * @see com.few.api.web.support.WorkBookCategory
+     */
+    val category: Byte,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/record/SelectWorkBookRecordWithSubscriptionCount.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/record/SelectWorkBookRecordWithSubscriptionCount.kt
@@ -1,0 +1,14 @@
+package com.few.api.repo.dao.workbook.record
+
+import java.net.URL
+import java.time.LocalDateTime
+
+data class SelectWorkBookRecordWithSubscriptionCount(
+    val id: Long,
+    val title: String,
+    val mainImageUrl: URL,
+    val category: Byte,
+    val description: String,
+    val createdAt: LocalDateTime,
+    val subscriptionCount: Long,
+)

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
@@ -2,6 +2,7 @@ package com.few.api.repo.explain.member
 
 import com.few.api.repo.dao.member.MemberDao
 import com.few.api.repo.dao.member.command.InsertMemberCommand
+import com.few.api.repo.dao.member.query.BrowseWorkbookWritersQuery
 import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
 import com.few.api.repo.dao.member.query.SelectWriterQuery
 import com.few.api.repo.dao.member.support.WriterDescription
@@ -73,6 +74,17 @@ class MemberDaoExplainGenerateTest : JooqTestSpec() {
         val explain = dslContext.explain(query).toString()
 
         ResultGenerator.execute(query, explain, "selectWriterQueryExplain")
+    }
+
+    @Test
+    fun selectWritersQueryByWorkbookIds() {
+        val query = BrowseWorkbookWritersQuery(listOf(1L, 2L)).let {
+            memberDao.selectWritersQuery(it)
+        }
+
+        val explain = dslContext.explain(query).toString()
+
+        ResultGenerator.execute(query, explain, "selectWritersQueryByWorkbookIds")
     }
 
     @Test

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/workbook/WorkbookDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/workbook/WorkbookDaoExplainGenerateTest.kt
@@ -2,6 +2,7 @@ package com.few.api.repo.explain.workbook
 
 import com.few.api.repo.dao.workbook.WorkbookDao
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
+import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import com.few.api.repo.explain.InsertUpdateExplainGenerator
 import com.few.api.repo.explain.ResultGenerator
@@ -65,5 +66,27 @@ class WorkbookDaoExplainGenerateTest : JooqTestSpec() {
 
         val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
         ResultGenerator.execute(command, explain, "insertWorkBookCommandExplain")
+    }
+
+    @Test
+    fun browseWorkBookQueryNoConditionQueryExplain() {
+        val query = BrowseWorkBookQueryWithSubscriptionCount(-1).let {
+            workbookDao.browseWorkBookQuery(it)
+        }
+
+        val explain = dslContext.explain(query).toString()
+
+        ResultGenerator.execute(query, explain, "browseWorkBookQueryNoConditionQuery")
+    }
+
+    @Test
+    fun browseWorkBookQueryCategoryConditionExplain() {
+        val query = BrowseWorkBookQueryWithSubscriptionCount(CategoryType.fromCode(0)!!.code).let {
+            workbookDao.browseWorkBookQuery(it)
+        }
+
+        val explain = dslContext.explain(query).toString()
+
+        ResultGenerator.execute(query, explain, "browseWorkBookQueryCategoryCondition")
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookMemberService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookMemberService.kt
@@ -1,9 +1,12 @@
 package com.few.api.domain.workbook.service
 
+import com.few.api.domain.workbook.service.dto.BrowseWorkbookWriterRecordsInDto
 import com.few.api.domain.workbook.usecase.dto.WriterDetail
 import com.few.api.domain.workbook.service.dto.BrowseWriterRecordsInDto
+import com.few.api.domain.workbook.service.dto.WriterMappedWorkbookOutDto
 import com.few.api.domain.workbook.service.dto.WriterOutDto
 import com.few.api.repo.dao.member.MemberDao
+import com.few.api.repo.dao.member.query.BrowseWorkbookWritersQuery
 import com.few.api.repo.dao.member.query.SelectWritersQuery
 import org.springframework.stereotype.Service
 
@@ -24,6 +27,23 @@ class WorkbookMemberService(
                     url = record.url
                 )
             }
+        }
+    }
+
+    /**
+     * key: workbookId
+     * value: writer list
+     */
+    fun browseWorkbookWriterRecords(query: BrowseWorkbookWriterRecordsInDto): Map<Long, List<WriterMappedWorkbookOutDto>> {
+        return BrowseWorkbookWritersQuery(query.workbookIds).let { query ->
+            memberDao.selectWriters(query).map { record ->
+                WriterMappedWorkbookOutDto(
+                    workbookId = record.workbookId,
+                    writerId = record.writerId,
+                    name = record.name,
+                    url = record.url
+                )
+            }.groupBy { it.workbookId }
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/workbook/service/dto/BrowseWorkbookWriterRecordsInDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/service/dto/BrowseWorkbookWriterRecordsInDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.workbook.service.dto
+
+data class BrowseWorkbookWriterRecordsInDto(
+    val workbookIds: List<Long>,
+)

--- a/api/src/main/kotlin/com/few/api/domain/workbook/service/dto/WriterMappedWorkbookOutDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/service/dto/WriterMappedWorkbookOutDto.kt
@@ -1,0 +1,10 @@
+package com.few.api.domain.workbook.service.dto
+
+import java.net.URL
+
+data class WriterMappedWorkbookOutDto(
+    val workbookId: Long,
+    val writerId: Long,
+    val name: String,
+    val url: URL,
+)

--- a/api/src/main/kotlin/com/few/api/domain/workbook/usecase/BrowseWorkbooksUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/usecase/BrowseWorkbooksUseCase.kt
@@ -1,0 +1,55 @@
+package com.few.api.domain.workbook.usecase
+
+import com.few.api.domain.workbook.service.WorkbookMemberService
+import com.few.api.domain.workbook.service.dto.BrowseWorkbookWriterRecordsInDto
+import com.few.api.domain.workbook.usecase.dto.BrowseWorkBookDetail
+import com.few.api.domain.workbook.usecase.dto.BrowseWorkbooksUseCaseIn
+import com.few.api.domain.workbook.usecase.dto.BrowseWorkbooksUseCaseOut
+import com.few.api.domain.workbook.usecase.dto.WriterDetail
+import com.few.api.repo.dao.workbook.WorkbookDao
+import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
+import com.few.data.common.code.CategoryType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class BrowseWorkbooksUseCase(
+    private val workbookDao: WorkbookDao,
+    private val workbookMemberService: WorkbookMemberService,
+) {
+
+    @Transactional
+    fun execute(useCaseIn: BrowseWorkbooksUseCaseIn): BrowseWorkbooksUseCaseOut {
+        val workbookRecords = BrowseWorkBookQueryWithSubscriptionCount(useCaseIn.category.code).let { query ->
+            workbookDao.browseWorkBookWithSubscriptionCount(query)
+        }
+
+        val workbookIds = workbookRecords.map { it.id }
+        val writerRecords = BrowseWorkbookWriterRecordsInDto(workbookIds).let { query ->
+            workbookMemberService.browseWorkbookWriterRecords(query)
+        }
+
+        val workbookDetails = workbookRecords.map { record ->
+            BrowseWorkBookDetail(
+                id = record.id,
+                mainImageUrl = record.mainImageUrl,
+                title = record.title,
+                description = record.description,
+                category = CategoryType.convertToDisplayName(record.category),
+                createdAt = record.createdAt,
+                writerDetails = writerRecords[record.id]?.map {
+                    WriterDetail(
+                        id = it.writerId,
+                        name = it.name,
+                        url = it.url
+                    )
+                } ?: emptyList(),
+                subscriptionCount = record.subscriptionCount
+            )
+        }
+
+        return BrowseWorkbooksUseCaseOut(
+            workbooks = workbookDetails
+        )
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/workbook/usecase/dto/BrowseWorkbooksUseCaseIn.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/usecase/dto/BrowseWorkbooksUseCaseIn.kt
@@ -1,0 +1,7 @@
+package com.few.api.domain.workbook.usecase.dto
+
+import com.few.api.web.support.WorkBookCategory
+
+data class BrowseWorkbooksUseCaseIn(
+    val category: WorkBookCategory,
+)

--- a/api/src/main/kotlin/com/few/api/domain/workbook/usecase/dto/BrowseWorkbooksUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/usecase/dto/BrowseWorkbooksUseCaseOut.kt
@@ -1,0 +1,19 @@
+package com.few.api.domain.workbook.usecase.dto
+
+import java.net.URL
+import java.time.LocalDateTime
+
+data class BrowseWorkbooksUseCaseOut(
+    val workbooks: List<BrowseWorkBookDetail>,
+)
+
+data class BrowseWorkBookDetail(
+    val id: Long,
+    val mainImageUrl: URL,
+    val title: String,
+    val description: String,
+    val category: String,
+    val createdAt: LocalDateTime,
+    val writerDetails: List<WriterDetail>,
+    val subscriptionCount: Long,
+)

--- a/api/src/test/kotlin/com/few/api/domain/workbook/usecase/BrowseWorkbooksUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/workbook/usecase/BrowseWorkbooksUseCaseTest.kt
@@ -1,0 +1,79 @@
+package com.few.api.domain.workbook.usecase
+
+import com.few.api.domain.workbook.service.WorkbookMemberService
+import com.few.api.domain.workbook.service.dto.WriterMappedWorkbookOutDto
+import com.few.api.domain.workbook.usecase.dto.BrowseWorkbooksUseCaseIn
+import com.few.api.repo.dao.workbook.WorkbookDao
+import com.few.api.repo.dao.workbook.record.SelectWorkBookRecordWithSubscriptionCount
+import com.few.api.web.support.WorkBookCategory
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import java.net.URL
+import java.time.LocalDateTime
+
+class BrowseWorkbooksUseCaseTest : BehaviorSpec({
+    lateinit var workbookDao: WorkbookDao
+    lateinit var workbookMemberService: WorkbookMemberService
+    lateinit var useCase: BrowseWorkbooksUseCase
+
+    beforeContainer {
+        workbookDao = mockk<WorkbookDao>()
+        workbookMemberService = mockk<WorkbookMemberService>()
+        useCase = BrowseWorkbooksUseCase(workbookDao, workbookMemberService)
+    }
+
+    given("다수 워크북 조회 요청이 온 상황에서") {
+        `when`("카테고리가 지정되어 있을 경우") {
+            every { workbookDao.browseWorkBookWithSubscriptionCount(any()) } returns listOf(
+                SelectWorkBookRecordWithSubscriptionCount(
+                    id = 1L,
+                    title = "workbook title",
+                    mainImageUrl = URL("https://jh-labs.tistory.com/"),
+                    category = (10).toByte(),
+                    description = "workbook description",
+                    createdAt = LocalDateTime.now(),
+                    subscriptionCount = 10
+                ),
+                SelectWorkBookRecordWithSubscriptionCount(
+                    id = 2L,
+                    title = "workbook title",
+                    mainImageUrl = URL("https://jh-labs.tistory.com/"),
+                    category = (10).toByte(),
+                    description = "workbook description",
+                    createdAt = LocalDateTime.now(),
+                    subscriptionCount = 10
+                )
+            )
+
+            every { workbookMemberService.browseWorkbookWriterRecords(any()) } returns mapOf(
+                1L to listOf(
+                    WriterMappedWorkbookOutDto(
+                        writerId = 1L,
+                        name = "hunca",
+                        url = URL("https://jh-labs.tistory.com/"),
+                        workbookId = 1L
+                    )
+                ),
+                2L to listOf(
+                    WriterMappedWorkbookOutDto(
+                        writerId = 2L,
+                        name = "hunca",
+                        url = URL("https://jh-labs.tistory.com/"),
+                        workbookId = 2L
+                    )
+                )
+            )
+
+            then("지정한 카테고리의 워크북이 조회된다") {
+                val useCaseIn = BrowseWorkbooksUseCaseIn(category = WorkBookCategory.All)
+                useCase.execute(useCaseIn)
+
+                verify(exactly = 1) { workbookDao.browseWorkBookWithSubscriptionCount(any()) }
+                verify(exactly = 1) { workbookMemberService.browseWorkbookWriterRecords(any()) }
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/few/api/web/controller/workbook/WorkBookControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/workbook/WorkBookControllerTest.kt
@@ -6,11 +6,9 @@ import com.epages.restdocs.apispec.ResourceDocumentation.resource
 import com.epages.restdocs.apispec.ResourceSnippetParameters
 import com.epages.restdocs.apispec.Schema
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.few.api.domain.workbook.usecase.dto.ArticleDetail
-import com.few.api.domain.workbook.usecase.dto.ReadWorkbookUseCaseIn
-import com.few.api.domain.workbook.usecase.dto.ReadWorkbookUseCaseOut
-import com.few.api.domain.workbook.usecase.dto.WriterDetail
+import com.few.api.domain.workbook.usecase.BrowseWorkbooksUseCase
 import com.few.api.domain.workbook.usecase.ReadWorkbookUseCase
+import com.few.api.domain.workbook.usecase.dto.*
 import com.few.api.web.controller.ControllerTestSpec
 import com.few.api.web.controller.description.Description
 import com.few.api.web.controller.helper.*
@@ -52,6 +50,9 @@ class WorkBookControllerTest : ControllerTestSpec() {
 
     @MockBean
     private lateinit var readWorkbookUseCase: ReadWorkbookUseCase
+
+    @MockBean
+    private lateinit var browseWorkBooksUseCase: BrowseWorkbooksUseCase
 
     companion object {
         private val BASE_URL = "/api/v1/workbooks"
@@ -127,6 +128,26 @@ class WorkBookControllerTest : ControllerTestSpec() {
             .toUriString()
 
         // set usecase mock
+        `when`(browseWorkBooksUseCase.execute(BrowseWorkbooksUseCaseIn(WorkBookCategory.ECONOMY))).thenReturn(
+            BrowseWorkbooksUseCaseOut(
+                workbooks = listOf(
+                    BrowseWorkBookDetail(
+                        id = 1L,
+                        mainImageUrl = URL("http://localhost:8080/api/v1/workbooks/1/image"),
+                        title = "재태크, 투자 필수 용어 모음집",
+                        description = "사회 초년생부터, 직장인, 은퇴자까지 모두가 알아야 할 기본적인 재태크, 투자 필수 용어 모음집 입니다.",
+                        category = CategoryType.fromCode(0)!!.name,
+                        createdAt = LocalDateTime.now(),
+                        writerDetails = listOf(
+                            WriterDetail(1L, "안나포", URL("http://localhost:8080/api/v1/users/1")),
+                            WriterDetail(2L, "퓨퓨", URL("http://localhost:8080/api/v1/users/2")),
+                            WriterDetail(3L, "프레소", URL("http://localhost:8080/api/v1/users/3"))
+                        ),
+                        subscriptionCount = 100
+                    )
+                )
+            )
+        )
 
         // when
         mockMvc.perform(
@@ -144,7 +165,7 @@ class WorkBookControllerTest : ControllerTestSpec() {
                         .tag(TAG)
                         .requestSchema(Schema.schema(api.toRequestSchema()))
                         .queryParameters(
-                            parameterWithName("category").description("학습지 카테고리")
+                            parameterWithName("category").description("학습지 카테고리").optional()
                         )
                         .responseSchema(Schema.schema(api.toResponseSchema())).responseFields(
                             *Description.describe(


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #240

💁‍♂️ PR 내용
----
- 메인 워크북 API 구현 - 워크북 API 

🙏 작업
----
- selectWriters 구현: workbookId를 가지고 writer 정보 조회
- browseWorkBookWithSubscriptionCount 구현: workbook 정보를 구독자 정보와 함께 조회 / 정렬의 경우 (구독자수, 생성일(최근)) 순으로 구현

🙈 PR 참고 사항
----

📸 스크린샷
----
## category 파람이 null 인 경우
![스크린샷 2024-07-29 오전 11 13 25](https://github.com/user-attachments/assets/d342b5d7-05c5-4888-9de0-f4dfd706abc8)

## 구독자, 생성일(최근) 정렬 결과
![스크린샷 2024-07-29 오전 11 14 35](https://github.com/user-attachments/assets/e905b078-7840-4733-a356-47342e33704b)

## category 파람이 정확한 경우
![스크린샷 2024-07-29 오전 11 14 54](https://github.com/user-attachments/assets/a8de87a2-b470-4525-94aa-3d6f62b8522e)

## category 파람이 정확하지 않은 경우 <- 전체 조회 결과 반환
![스크린샷 2024-07-29 오전 11 15 11](https://github.com/user-attachments/assets/e35e456b-b502-47de-ad9f-005eb8b79706)


🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
