### PR TITLE
[Feat/#241] 메인 워크북 API 구현 - 회원 워크북 API

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleDao.kt
@@ -3,6 +3,7 @@ package com.few.api.repo.dao.article
 import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
 import com.few.api.repo.config.LocalCacheConfig.Companion.SELECT_ARTICLE_RECORD_CACHE
 import com.few.api.repo.dao.article.command.InsertFullArticleRecordCommand
+import com.few.api.repo.dao.article.query.SelectArticleIdByWorkbookIdAndDayQuery
 import com.few.api.repo.dao.article.query.SelectArticleRecordQuery
 import com.few.api.repo.dao.article.query.SelectWorkBookArticleRecordQuery
 import com.few.api.repo.dao.article.query.SelectWorkbookMappedArticleRecordsQuery
@@ -112,4 +113,17 @@ class ArticleDao(
     ) = dslContext.insertInto(ArticleIfo.ARTICLE_IFO)
         .set(ArticleIfo.ARTICLE_IFO.ARTICLE_MST_ID, mstId)
         .set(ArticleIfo.ARTICLE_IFO.CONTENT, command.content)
+
+    fun selectArticleIdByWorkbookIdAndDay(query: SelectArticleIdByWorkbookIdAndDayQuery): Long? {
+        return selectArticleIdByWorkbookIdAndDayQuery(query)
+            .fetchOneInto(Long::class.java)
+    }
+
+    fun selectArticleIdByWorkbookIdAndDayQuery(query: SelectArticleIdByWorkbookIdAndDayQuery) =
+        dslContext.select(
+            MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.ARTICLE_ID
+        ).from(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE)
+            .where(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.WORKBOOK_ID.eq(query.workbookId))
+            .and(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DAY_COL.eq(query.day))
+            .query
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/query/SelectArticleIdByWorkbookIdAndDayQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/query/SelectArticleIdByWorkbookIdAndDayQuery.kt
@@ -1,0 +1,6 @@
+package com.few.api.repo.dao.article.query
+
+data class SelectArticleIdByWorkbookIdAndDayQuery(
+    val workbookId: Long,
+    val day: Int,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountAllWorkbooksSubscription.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountAllWorkbooksSubscription.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.subscription.query
+
+data class CountAllWorkbooksSubscription(
+    val workbookIds: List<Long>,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery.kt
@@ -1,0 +1,8 @@
+package com.few.api.repo.dao.subscription.query
+
+/**
+ * DeleteAt을 고려하지 않고 멤버의 모든 워크북 구독 상태를 조회하는 쿼리
+ */
+data class SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery(
+    val memberId: Long,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/MemberWorkbookSubscriptionStatusRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/MemberWorkbookSubscriptionStatusRecord.kt
@@ -1,0 +1,8 @@
+package com.few.api.repo.dao.subscription.record
+
+data class MemberWorkbookSubscriptionStatusRecord(
+    val workbookId: Long,
+    val isActiveSub: Boolean,
+    val currentDay: Int,
+    val totalDay: Int,
+)

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/article/ArticleDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/article/ArticleDaoExplainGenerateTest.kt
@@ -2,6 +2,7 @@ package com.few.api.repo.explain.article
 
 import com.few.api.repo.dao.article.ArticleDao
 import com.few.api.repo.dao.article.command.InsertFullArticleRecordCommand
+import com.few.api.repo.dao.article.query.SelectArticleIdByWorkbookIdAndDayQuery
 import com.few.api.repo.dao.article.query.SelectArticleRecordQuery
 import com.few.api.repo.dao.article.query.SelectWorkBookArticleRecordQuery
 import com.few.api.repo.dao.article.query.SelectWorkbookMappedArticleRecordsQuery
@@ -121,5 +122,16 @@ class ArticleDaoExplainGenerateTest : JooqTestSpec() {
         val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
 
         ResultGenerator.execute(command, explain, "insertArticleIfoCommandExplain")
+    }
+
+    @Test
+    fun selectArticleIdByWorkbookIdAndDayQueryExplain() {
+        val query = SelectArticleIdByWorkbookIdAndDayQuery(1L, 1).let {
+            articleDao.selectArticleIdByWorkbookIdAndDayQuery(it)
+        }
+
+        val explain = dslContext.explain(query).toString()
+
+        ResultGenerator.execute(query, explain, "selectArticleIdByWorkbookIdAndDayQueryExplain")
     }
 }

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
@@ -5,6 +5,7 @@ import com.few.api.repo.dao.subscription.command.InsertWorkbookSubscriptionComma
 import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInAllSubscriptionCommand
 import com.few.api.repo.dao.subscription.query.CountWorkbookMappedArticlesQuery
 import com.few.api.repo.dao.subscription.query.SelectAllWorkbookSubscriptionStatusNotConsiderDeletedAtQuery
+import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery
 import com.few.api.repo.explain.InsertUpdateExplainGenerator
 import com.few.api.repo.explain.ResultGenerator
 import com.few.api.repo.jooq.JooqTestSpec
@@ -60,6 +61,17 @@ class SubscriptionDaoExplainGenerateTest : JooqTestSpec() {
     }
 
     @Test
+    fun selectAllTopWorkbookSubscriptionStatusQueryExplain() {
+        val query = SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery(memberId = 1L).let {
+            subscriptionDao.selectAllWorkbookSubscriptionStatusQuery(it)
+        }
+
+        val explain = dslContext.explain(query).toString()
+
+        ResultGenerator.execute(query, explain, "selectAllTopWorkbookSubscriptionStatusQueryExplain")
+    }
+
+    @Test
     fun countWorkbookMappedArticlesQueryExplain() {
         val query = CountWorkbookMappedArticlesQuery(
             workbookId = 1L
@@ -98,5 +110,14 @@ class SubscriptionDaoExplainGenerateTest : JooqTestSpec() {
         val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
 
         ResultGenerator.execute(command, explain, "updateDeletedAtInAllSubscriptionCommandExplain")
+    }
+
+    @Test
+    fun countAllWorkbookSubscriptionQueryExplain() {
+        val query = subscriptionDao.countAllWorkbookSubscriptionQuery()
+
+        val explain = dslContext.explain(query).toString()
+
+        ResultGenerator.execute(query, explain, "countAllWorkbookSubscriptionQueryExplain")
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionArticleService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionArticleService.kt
@@ -1,0 +1,17 @@
+package com.few.api.domain.subscription.service
+
+import com.few.api.domain.subscription.service.dto.ReadArticleIdByWorkbookIdAndDayDto
+import com.few.api.repo.dao.article.ArticleDao
+import com.few.api.repo.dao.article.query.SelectArticleIdByWorkbookIdAndDayQuery
+import org.springframework.stereotype.Service
+
+@Service
+class SubscriptionArticleService(
+    private val articleDao: ArticleDao,
+) {
+    fun readArticleIdByWorkbookIdAndDay(dto: ReadArticleIdByWorkbookIdAndDayDto): Long? {
+        SelectArticleIdByWorkbookIdAndDayQuery(dto.workbookId, dto.day).let { query ->
+            return articleDao.selectArticleIdByWorkbookIdAndDay(query)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadArticleIdByWorkbookIdAndDayDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadArticleIdByWorkbookIdAndDayDto.kt
@@ -1,0 +1,6 @@
+package com.few.api.domain.subscription.service.dto
+
+data class ReadArticleIdByWorkbookIdAndDayDto(
+    val workbookId: Long,
+    val day: Int,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCase.kt
@@ -1,0 +1,52 @@
+package com.few.api.domain.subscription.usecase
+
+import com.few.api.domain.subscription.usecase.dto.BrowseSubscribeWorkbooksUseCaseIn
+import com.few.api.domain.subscription.usecase.dto.BrowseSubscribeWorkbooksUseCaseOut
+import com.few.api.domain.subscription.usecase.dto.SubscribeWorkbookDetail
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import com.few.api.repo.dao.subscription.query.CountAllWorkbooksSubscription
+import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery
+import com.few.api.web.support.WorkBookStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class BrowseSubscribeWorkbooksUseCase(
+    private val subscriptionDao: SubscriptionDao,
+) {
+    @Transactional
+    fun execute(useCaseIn: BrowseSubscribeWorkbooksUseCaseIn): BrowseSubscribeWorkbooksUseCaseOut {
+        val subscriptionRecords =
+            SelectAllMemberWorkbookSubscriptionStatusNotConsiderDeletedAtQuery(useCaseIn.memberId).let {
+                subscriptionDao.selectAllWorkbookSubscriptionStatus(it)
+            }
+
+        val subscriptionWorkbookIds = subscriptionRecords.map { it.workbookId }
+        val workbookSubscriptionCountRecords =
+            CountAllWorkbooksSubscription(subscriptionWorkbookIds).let {
+                subscriptionDao.countAllWorkbookSubscription(it)
+            }
+
+        subscriptionRecords.map {
+            /**
+             * 임시 코드
+             * Batch 코드에서 currentDay가 totalDay보다 큰 경우가 발생하여
+             * currentDay가 totalDay보다 크면 totalDay로 변경
+             * */
+            var currentDay = it.currentDay
+            if (it.currentDay > it.totalDay) {
+                currentDay = it.totalDay
+            }
+
+            SubscribeWorkbookDetail(
+                workbookId = it.workbookId,
+                isActiveSub = WorkBookStatus.fromStatus(it.isActiveSub),
+                currentDay = currentDay,
+                totalDay = it.totalDay,
+                totalSubscriber = workbookSubscriptionCountRecords[it.workbookId]?.toLong() ?: 0
+            )
+        }.let {
+            return BrowseSubscribeWorkbooksUseCaseOut(it)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/usecase/dto/BrowseSubscribeWorkbooksUseCaseIn.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/usecase/dto/BrowseSubscribeWorkbooksUseCaseIn.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.subscription.usecase.dto
+
+data class BrowseSubscribeWorkbooksUseCaseIn(
+    val memberId: Long,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/usecase/dto/BrowseSubscribeWorkbooksUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/usecase/dto/BrowseSubscribeWorkbooksUseCaseOut.kt
@@ -1,0 +1,17 @@
+package com.few.api.domain.subscription.usecase.dto
+
+import com.few.api.web.support.WorkBookStatus
+
+data class BrowseSubscribeWorkbooksUseCaseOut(
+    val workbooks: List<SubscribeWorkbookDetail>,
+)
+
+data class SubscribeWorkbookDetail(
+    val workbookId: Long,
+    val isActiveSub: WorkBookStatus,
+    val currentDay: Int,
+    val totalDay: Int,
+    val rank: Long = 0,
+    val totalSubscriber: Long,
+    val articleInfo: String = "{}",
+)

--- a/api/src/main/kotlin/com/few/api/web/controller/subscription/SubscriptionController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/subscription/SubscriptionController.kt
@@ -42,7 +42,7 @@ class SubscriptionController(
         ) view: ViewCategory? = ViewCategory.MAIN_CARD,
     ): ApiResponse<ApiResponse.SuccessBody<SubscribeWorkbooksResponse>> {
         // todo fix memberId
-        val memberId = 1L
+        val memberId = 52L
         val useCaseOut = BrowseSubscribeWorkbooksUseCaseIn(memberId).let {
             browseSubscribeWorkbooksUseCase.execute(it)
         }

--- a/api/src/main/kotlin/com/few/api/web/controller/subscription/SubscriptionController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/subscription/SubscriptionController.kt
@@ -1,5 +1,6 @@
 package com.few.api.web.controller.subscription
 
+import com.few.api.domain.subscription.usecase.BrowseSubscribeWorkbooksUseCase
 import com.few.api.web.controller.subscription.request.SubscribeWorkbookRequest
 import com.few.api.web.controller.subscription.request.UnsubscribeWorkbookRequest
 import com.few.api.web.support.ApiResponse
@@ -7,6 +8,7 @@ import com.few.api.web.support.ApiResponseGenerator
 import com.few.api.domain.subscription.usecase.SubscribeWorkbookUseCase
 import com.few.api.domain.subscription.usecase.UnsubscribeAllUseCase
 import com.few.api.domain.subscription.usecase.UnsubscribeWorkbookUseCase
+import com.few.api.domain.subscription.usecase.dto.BrowseSubscribeWorkbooksUseCaseIn
 import com.few.api.domain.subscription.usecase.dto.SubscribeWorkbookUseCaseIn
 import com.few.api.domain.subscription.usecase.dto.UnsubscribeAllUseCaseIn
 import com.few.api.domain.subscription.usecase.dto.UnsubscribeWorkbookUseCaseIn
@@ -28,6 +30,7 @@ class SubscriptionController(
     private val subscribeWorkbookUseCase: SubscribeWorkbookUseCase,
     private val unsubscribeWorkbookUseCase: UnsubscribeWorkbookUseCase,
     private val unsubscribeAllUseCase: UnsubscribeAllUseCase,
+    private val browseSubscribeWorkbooksUseCase: BrowseSubscribeWorkbooksUseCase,
 ) {
 
     // todo add auth
@@ -38,29 +41,26 @@ class SubscriptionController(
             required = false
         ) view: ViewCategory? = ViewCategory.MAIN_CARD,
     ): ApiResponse<ApiResponse.SuccessBody<SubscribeWorkbooksResponse>> {
-        SubscribeWorkbooksResponse(
-            listOf(
+        // todo fix memberId
+        val memberId = 1L
+        val useCaseOut = BrowseSubscribeWorkbooksUseCaseIn(memberId).let {
+            browseSubscribeWorkbooksUseCase.execute(it)
+        }
+
+        return SubscribeWorkbooksResponse(
+            workbooks = useCaseOut.workbooks.map {
                 SubscribeWorkbookInfo(
-                    id = 1,
-                    status = "ACTIVE",
-                    totalDay = 10,
-                    currentDay = 1,
-                    rank = 0,
-                    totalSubscriber = 100,
-                    articleInfo = "{}"
-                ),
-                SubscribeWorkbookInfo(
-                    id = 2,
-                    status = "DONE",
-                    totalDay = 10,
-                    currentDay = 10,
-                    rank = 22,
-                    totalSubscriber = 100,
-                    articleInfo = "{}"
+                    id = it.workbookId,
+                    currentDay = it.currentDay,
+                    totalDay = it.totalDay,
+                    status = it.isActiveSub.name,
+                    rank = it.rank,
+                    totalSubscriber = it.totalSubscriber,
+                    articleInfo = it.articleInfo
                 )
-            )
+            }
         ).let {
-            return ApiResponseGenerator.success(it, HttpStatus.OK)
+            ApiResponseGenerator.success(it, HttpStatus.OK)
         }
     }
 

--- a/api/src/main/kotlin/com/few/api/web/controller/subscription/SubscriptionController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/subscription/SubscriptionController.kt
@@ -42,7 +42,7 @@ class SubscriptionController(
         ) view: ViewCategory? = ViewCategory.MAIN_CARD,
     ): ApiResponse<ApiResponse.SuccessBody<SubscribeWorkbooksResponse>> {
         // todo fix memberId
-        val memberId = 52L
+        val memberId = 1L
         val useCaseOut = BrowseSubscribeWorkbooksUseCaseIn(memberId).let {
             browseSubscribeWorkbooksUseCase.execute(it)
         }

--- a/api/src/main/kotlin/com/few/api/web/support/WorkBookStatus.kt
+++ b/api/src/main/kotlin/com/few/api/web/support/WorkBookStatus.kt
@@ -1,0 +1,16 @@
+package com.few.api.web.support
+
+enum class WorkBookStatus {
+    ACTIVE,
+    DONE,
+    ;
+
+    companion object {
+        /**
+         * status ture -> ACTIVE, false -> DONE
+         */
+        fun fromStatus(status: Boolean): WorkBookStatus {
+            return if (status) ACTIVE else DONE
+        }
+    }
+}

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCaseTest.kt
@@ -1,0 +1,53 @@
+package com.few.api.domain.subscription.usecase
+
+import com.few.api.domain.subscription.usecase.dto.BrowseSubscribeWorkbooksUseCaseIn
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import com.few.api.repo.dao.subscription.record.MemberWorkbookSubscriptionStatusRecord
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class BrowseSubscribeWorkbooksUseCaseTest : BehaviorSpec({
+    val log = KotlinLogging.logger {}
+
+    lateinit var subscriptionDao: SubscriptionDao
+    lateinit var useCase: BrowseSubscribeWorkbooksUseCase
+
+    beforeContainer {
+        subscriptionDao = mockk<SubscriptionDao>()
+        useCase = BrowseSubscribeWorkbooksUseCase(subscriptionDao)
+    }
+
+    given("사용자 구독 정보 조회 요청이 온 상황에서") {
+        `when`("사용자의 구독 정보가 있는 경우") {
+            every { subscriptionDao.selectAllWorkbookSubscriptionStatus(any()) } returns listOf(
+                MemberWorkbookSubscriptionStatusRecord(
+                    workbookId = 1L,
+                    isActiveSub = true,
+                    currentDay = 1,
+                    totalDay = 3
+                ),
+                MemberWorkbookSubscriptionStatusRecord(
+                    workbookId = 2L,
+                    isActiveSub = true,
+                    currentDay = 2,
+                    totalDay = 3
+                )
+            )
+            every { subscriptionDao.countAllWorkbookSubscription(any()) } returns mapOf(
+                1L to 1,
+                2L to 2
+            )
+
+            then("사용자의 구독 정보를 조회한다") {
+                val useCaseIn = BrowseSubscribeWorkbooksUseCaseIn(memberId = 1L)
+                useCase.execute(useCaseIn)
+
+                verify(exactly = 1) { subscriptionDao.selectAllWorkbookSubscriptionStatus(any()) }
+                verify(exactly = 1) { subscriptionDao.countAllWorkbookSubscription(any()) }
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCaseTest.kt
@@ -1,5 +1,7 @@
 package com.few.api.domain.subscription.usecase
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.few.api.domain.subscription.service.SubscriptionArticleService
 import com.few.api.domain.subscription.usecase.dto.BrowseSubscribeWorkbooksUseCaseIn
 import com.few.api.repo.dao.subscription.SubscriptionDao
 import com.few.api.repo.dao.subscription.record.MemberWorkbookSubscriptionStatusRecord
@@ -13,11 +15,15 @@ class BrowseSubscribeWorkbooksUseCaseTest : BehaviorSpec({
     val log = KotlinLogging.logger {}
 
     lateinit var subscriptionDao: SubscriptionDao
+    lateinit var subscriptionArticleService: SubscriptionArticleService
+    lateinit var objectMapper: ObjectMapper
     lateinit var useCase: BrowseSubscribeWorkbooksUseCase
 
     beforeContainer {
         subscriptionDao = mockk<SubscriptionDao>()
-        useCase = BrowseSubscribeWorkbooksUseCase(subscriptionDao)
+        subscriptionArticleService = mockk<SubscriptionArticleService>()
+        objectMapper = mockk<ObjectMapper>()
+        useCase = BrowseSubscribeWorkbooksUseCase(subscriptionDao, subscriptionArticleService, objectMapper)
     }
 
     given("사용자 구독 정보 조회 요청이 온 상황에서") {
@@ -36,6 +42,11 @@ class BrowseSubscribeWorkbooksUseCaseTest : BehaviorSpec({
                     totalDay = 3
                 )
             )
+
+            every {
+                subscriptionArticleService.readArticleIdByWorkbookIdAndDay(any())
+            } returns 1L andThen 2L
+
             every { subscriptionDao.countAllWorkbookSubscription(any()) } returns mapOf(
                 1L to 1,
                 2L to 2

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/BrowseSubscribeWorkbooksUseCaseTest.kt
@@ -52,12 +52,15 @@ class BrowseSubscribeWorkbooksUseCaseTest : BehaviorSpec({
                 2L to 2
             )
 
+            every { objectMapper.writeValueAsString(any()) } returns "{\"articleId\":1}" andThen "{\"articleId\":2}"
+
             then("사용자의 구독 정보를 조회한다") {
                 val useCaseIn = BrowseSubscribeWorkbooksUseCaseIn(memberId = 1L)
                 useCase.execute(useCaseIn)
 
                 verify(exactly = 1) { subscriptionDao.selectAllWorkbookSubscriptionStatus(any()) }
                 verify(exactly = 1) { subscriptionDao.countAllWorkbookSubscription(any()) }
+                verify(exactly = 2) { objectMapper.writeValueAsString(any()) }
             }
         }
     }

--- a/api/src/test/kotlin/com/few/api/web/controller/subscription/SubscriptionControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/subscription/SubscriptionControllerTest.kt
@@ -97,7 +97,7 @@ class SubscriptionControllerTest : ControllerTestSpec() {
                     totalDay = 3,
                     rank = 0,
                     totalSubscriber = 100,
-                    articleInfo = "{}"
+                    articleInfo = "{\"articleId\":1}"
                 ),
                 SubscribeWorkbookDetail(
                     workbookId = 2L,
@@ -106,7 +106,7 @@ class SubscriptionControllerTest : ControllerTestSpec() {
                     totalDay = 3,
                     rank = 0,
                     totalSubscriber = 1,
-                    articleInfo = "{}"
+                    articleInfo = "{\"articleId\":5}"
                 ),
                 SubscribeWorkbookDetail(
                     workbookId = 3L,

--- a/api/src/test/kotlin/com/few/api/web/controller/subscription/SubscriptionControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/subscription/SubscriptionControllerTest.kt
@@ -5,6 +5,7 @@ import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.epages.restdocs.apispec.ResourceSnippetParameters
 import com.epages.restdocs.apispec.Schema
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.few.api.domain.subscription.usecase.BrowseSubscribeWorkbooksUseCase
 import com.few.api.web.controller.ControllerTestSpec
 import com.few.api.web.controller.description.Description
 import com.few.api.web.controller.subscription.request.SubscribeWorkbookRequest
@@ -12,15 +13,15 @@ import com.few.api.web.controller.subscription.request.UnsubscribeWorkbookReques
 import com.few.api.domain.subscription.usecase.SubscribeWorkbookUseCase
 import com.few.api.domain.subscription.usecase.UnsubscribeAllUseCase
 import com.few.api.domain.subscription.usecase.UnsubscribeWorkbookUseCase
-import com.few.api.domain.subscription.usecase.dto.SubscribeWorkbookUseCaseIn
-import com.few.api.domain.subscription.usecase.dto.UnsubscribeAllUseCaseIn
-import com.few.api.domain.subscription.usecase.dto.UnsubscribeWorkbookUseCaseIn
+import com.few.api.domain.subscription.usecase.dto.*
 import com.few.api.web.controller.helper.*
 import com.few.api.web.support.ViewCategory
+import com.few.api.web.support.WorkBookStatus
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.doReturn
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
@@ -51,6 +52,9 @@ class SubscriptionControllerTest : ControllerTestSpec() {
     @MockBean
     private lateinit var unsubscribeAllUseCase: UnsubscribeAllUseCase
 
+    @MockBean
+    private lateinit var browseSubscribeWorkbooksUseCase: BrowseSubscribeWorkbooksUseCase
+
     companion object {
         private val BASE_URL = "/api/v1/"
         private val TAG = "WorkbookSubscriptionController"
@@ -80,6 +84,43 @@ class SubscriptionControllerTest : ControllerTestSpec() {
             .queryParam("view", view)
             .build()
             .toUriString()
+
+        // set usecase mock
+        val memberId = 1L
+        val useCaseIn = BrowseSubscribeWorkbooksUseCaseIn(memberId)
+        val useCaseOut = BrowseSubscribeWorkbooksUseCaseOut(
+            workbooks = listOf(
+                SubscribeWorkbookDetail(
+                    workbookId = 1L,
+                    isActiveSub = WorkBookStatus.ACTIVE,
+                    currentDay = 1,
+                    totalDay = 3,
+                    rank = 0,
+                    totalSubscriber = 100,
+                    articleInfo = "{}"
+                ),
+                SubscribeWorkbookDetail(
+                    workbookId = 2L,
+                    isActiveSub = WorkBookStatus.ACTIVE,
+                    currentDay = 2,
+                    totalDay = 3,
+                    rank = 0,
+                    totalSubscriber = 1,
+                    articleInfo = "{}"
+                ),
+                SubscribeWorkbookDetail(
+                    workbookId = 3L,
+                    isActiveSub = WorkBookStatus.DONE,
+                    currentDay = 3,
+                    totalDay = 3,
+                    rank = 0,
+                    totalSubscriber = 2,
+                    articleInfo = "{}"
+                )
+            )
+        )
+
+        doReturn(useCaseOut).`when`(browseSubscribeWorkbooksUseCase).execute(useCaseIn)
 
         // when
         this.webTestClient.get()


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #241 

💁‍♂️ PR 내용
----
- 메인 워크북 API 구현 - 회원 워크북 API

🙏 작업
----
- selectAllWorkbookSubscriptionStatus 쿼리 구현:  멤버의 구독 기록이 있는 워크북을 조회합니다.
- countAllWorkbookSubscription 쿼리 구현:  워크북의 구독자를 조회합니다.

🙈 PR 참고 사항
----

📸 스크린샷
----
![스크린샷 2024-07-29 오후 12 10 42](https://github.com/user-attachments/assets/70bb4767-8816-468a-8dd1-5eddc32201a6)


🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
