### PR TITLE
[Fix/#281] 아티클 조회수 순 정렬시 옵션 추가(article최신순)

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleViewCountDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleViewCountDao.kt
@@ -7,8 +7,6 @@ import com.few.api.repo.dao.article.query.SelectRankByViewsQuery
 import com.few.api.repo.dao.article.record.SelectArticleViewsRecord
 import jooq.jooq_dsl.tables.ArticleViewCount.ARTICLE_VIEW_COUNT
 import org.jooq.DSLContext
-import org.jooq.Record2
-import org.jooq.SelectLimitPercentStep
 import org.jooq.impl.DSL.*
 import org.springframework.stereotype.Repository
 
@@ -56,13 +54,12 @@ class ArticleViewCountDao(
     fun selectRankByViewsQuery(query: SelectRankByViewsQuery) = dslContext
         .select(field("row_rank_tb.offset", Long::class.java))
         .from(
-            dslContext
-                .select(
-                    ARTICLE_VIEW_COUNT.ARTICLE_ID,
-                    rowNumber().over(orderBy(ARTICLE_VIEW_COUNT.VIEW_COUNT.desc())).`as`("offset")
-                )
-                .from(ARTICLE_VIEW_COUNT)
-                .asTable("row_rank_tb")
+            dslContext.select(
+                ARTICLE_VIEW_COUNT.ARTICLE_ID,
+                rowNumber().over(
+                    orderBy(ARTICLE_VIEW_COUNT.VIEW_COUNT.desc(), ARTICLE_VIEW_COUNT.ARTICLE_ID.desc())
+                ).`as`("offset")
+            ).from(ARTICLE_VIEW_COUNT).asTable("row_rank_tb")
         )
         .where(field("row_rank_tb.${ARTICLE_VIEW_COUNT.ARTICLE_ID.name}")!!.eq(query.articleId))
         .query
@@ -73,26 +70,22 @@ class ArticleViewCountDao(
             .toSet()
     }
 
-    fun selectArticlesOrderByViewsQuery(query: SelectArticlesOrderByViewsQuery): SelectLimitPercentStep<Record2<Any, Any>> {
-        val articleViewCountOffsetTb = select()
-            .from(ARTICLE_VIEW_COUNT)
-            .where(ARTICLE_VIEW_COUNT.DELETED_AT.isNull)
-            .orderBy(ARTICLE_VIEW_COUNT.VIEW_COUNT.desc())
-            .limit(query.offset, Long.MAX_VALUE)
-            .asTable("article_view_count_offset_tb")
-
-        val baseQuery = dslContext.select(
+    fun selectArticlesOrderByViewsQuery(query: SelectArticlesOrderByViewsQuery) = dslContext
+        .select(
             field("article_view_count_offset_tb.article_id").`as`(SelectArticleViewsRecord::articleId.name),
             field("article_view_count_offset_tb.view_count").`as`(SelectArticleViewsRecord::views.name)
-        )
-            .from(articleViewCountOffsetTb)
-
-        return if (query.category != null) {
-            baseQuery.where(field("article_view_count_offset_tb.category_cd").eq(query.category.code))
-                .limit(10)
-        } else {
-            baseQuery
-                .limit(10)
-        } // TODO: .query로 리턴하면 리턴 타입이 달라져 못받는 문제
-    }
+        ).from(
+            select()
+                .from(ARTICLE_VIEW_COUNT)
+                .where(ARTICLE_VIEW_COUNT.DELETED_AT.isNull)
+                .orderBy(ARTICLE_VIEW_COUNT.VIEW_COUNT.desc(), ARTICLE_VIEW_COUNT.ARTICLE_ID.desc())
+                .limit(query.offset, Long.MAX_VALUE)
+                .asTable("article_view_count_offset_tb")
+        ).where(
+            when (query.category) {
+                (null) -> noCondition()
+                else -> field("article_view_count_offset_tb.category_cd").eq(query.category.code)
+            }
+        ).limit(10)
+        .query
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleViewCountDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleViewCountDao.kt
@@ -59,7 +59,9 @@ class ArticleViewCountDao(
                 rowNumber().over(
                     orderBy(ARTICLE_VIEW_COUNT.VIEW_COUNT.desc(), ARTICLE_VIEW_COUNT.ARTICLE_ID.desc())
                 ).`as`("offset")
-            ).from(ARTICLE_VIEW_COUNT).asTable("row_rank_tb")
+            ).from(ARTICLE_VIEW_COUNT)
+                .where(ARTICLE_VIEW_COUNT.DELETED_AT.isNull)
+                .asTable("row_rank_tb")
         )
         .where(field("row_rank_tb.${ARTICLE_VIEW_COUNT.ARTICLE_ID.name}")!!.eq(query.articleId))
         .query


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #281 

💁‍♂️ PR 내용
----
- DB에서 아티클 조회수 순 10개씩 조회 시, 아티클 최신순 옵션이 빠져있어 발생한 문제
    - DB에선 아티클 조회수 순 10개를 뽑아온 뒤, 그 10개를 애플리케이션에서 조회수가 같은 경우 최신순으로 정렬하고 있었음
    - 결국 디비 단에선 조회수가 같을 경우 아티클 최신순 조건이 발생되지 않음

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
