### PR TITLE
[Fix/#283] 아티클 개수가 10의 배수일 경우 마지막 스크롤에서 isLast=false로 응답되는 문제 해결

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleViewCountDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleViewCountDao.kt
@@ -66,10 +66,9 @@ class ArticleViewCountDao(
         .where(field("row_rank_tb.${ARTICLE_VIEW_COUNT.ARTICLE_ID.name}")!!.eq(query.articleId))
         .query
 
-    fun selectArticlesOrderByViews(query: SelectArticlesOrderByViewsQuery): Set<SelectArticleViewsRecord> {
+    fun selectArticlesOrderByViews(query: SelectArticlesOrderByViewsQuery): List<SelectArticleViewsRecord> {
         return selectArticlesOrderByViewsQuery(query)
             .fetchInto(SelectArticleViewsRecord::class.java)
-            .toSet()
     }
 
     fun selectArticlesOrderByViewsQuery(query: SelectArticlesOrderByViewsQuery) = dslContext
@@ -88,6 +87,6 @@ class ArticleViewCountDao(
                 (null) -> noCondition()
                 else -> field("article_view_count_offset_tb.category_cd").eq(query.category.code)
             }
-        ).limit(10)
+        ).limit(11)
         .query
 }

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticlesUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticlesUseCase.kt
@@ -35,12 +35,19 @@ class ReadArticlesUseCase(
         }
 
         // 이번 스크롤에서 보여줄 아티클 ID에 대한 기준 (Criterion)
-        val articleViewsRecords: Set<SelectArticleViewsRecord> = articleViewCountDao.selectArticlesOrderByViews(
+        val articleViewsRecords: MutableList<SelectArticleViewsRecord> = articleViewCountDao.selectArticlesOrderByViews(
             SelectArticlesOrderByViewsQuery(
                 offset,
                 CategoryType.fromCode(useCaseIn.categoryCd)
             )
-        )
+        ).toMutableList()
+
+        val isLast = if (articleViewsRecords.size == 11) {
+            articleViewsRecords.removeAt(10)
+            false
+        } else {
+            true
+        }
 
         // 2. TODO: 조회한 10개의 아티클 아이디를 기반으로 로컬 캐시에 있는지 조회(아티클 단건조회 캐시 사용)
         // 3. TODO: 로컬캐시에 없으면 ARTICLE_MAIN_CARD 테이블에서 데이터가 있는지 조회 (컨텐츠는 article_ifo에서)
@@ -97,12 +104,12 @@ class ReadArticlesUseCase(
             )
         }.toList()
 
-        return ReadArticlesUseCaseOut(articleUseCaseOuts, sortedArticles.size != 10)
+        return ReadArticlesUseCaseOut(articleUseCaseOuts, isLast)
     }
 
     private fun updateAndSortArticleViews(
         articleRecords: Set<ArticleMainCardRecord>,
-        articleViewsRecords: Set<SelectArticleViewsRecord>,
+        articleViewsRecords: List<SelectArticleViewsRecord>,
     ): Set<ArticleMainCardRecord> {
         val sortedSet = TreeSet(
             Comparator<ArticleMainCardRecord> { a1, a2 ->

--- a/data/src/main/kotlin/com/few/data/common/code/CategoryType.kt
+++ b/data/src/main/kotlin/com/few/data/common/code/CategoryType.kt
@@ -4,6 +4,7 @@ package com.few.data.common.code
  * @see com.few.batch.data.common.code.BatchCategoryType
  */
 enum class CategoryType(val code: Byte, val displayName: String) {
+    All(-1, "전체"), // Should not be stored in the DB
     ECONOMY(0, "경제"),
     IT(10, "IT"),
     MARKETING(20, "마케팅"),


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #283 

💁‍♂️ PR 내용
----
- as-is: DB에서 Limit 10으로 조회 후 10개가 조회되었다면 isLast = false로 응답
    - 아티클이 10의 배수로 존재할 경우 문제될 수 있음: 마지막 스크롤에서 10개를 응답했지만 isLast = false로 응답됨
- to-be: DB에서 조회시 limit 11로 조회하여 조회된 개수가 11개일 경우 isLast = false, 그렇지 않을 경우 isLast = true로 응답

🙏 작업
----

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
