### PR TITLE
[Feat/#293] 작가 description json 필드 추가 - imageUrl(required)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ api-repo/**/*.sql
 batch/**/*.sql
 email/**/*.sql
 storage/**/*.sql
+
+# DB explain result files
+**/resources/explain/

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleMainCardDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleMainCardDao.kt
@@ -71,7 +71,8 @@ class ArticleMainCardDao(
                 commonJsonMapper.toJsonStr(
                     mapOf(
                         "name" to command.writerName,
-                        "url" to command.writerImgUrl
+                        "url" to command.writerUrl,
+                        "imageUrl" to command.writerImgUrl
                     )
                 )
             )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleMainCardDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/ArticleMainCardDao.kt
@@ -35,7 +35,8 @@ class ArticleMainCardDao(
             ARTICLE_MAIN_CARD.WRITER_DESCRIPTION,
             "name"
         ).`as`(ArticleMainCardRecord::writerName.name),
-        jsonGetAttribute(ARTICLE_MAIN_CARD.WRITER_DESCRIPTION, "url").`as`(ArticleMainCardRecord::writerImgUrl.name),
+        jsonGetAttribute(ARTICLE_MAIN_CARD.WRITER_DESCRIPTION, "url").`as`(ArticleMainCardRecord::writerUrl.name),
+        jsonGetAttribute(ARTICLE_MAIN_CARD.WRITER_DESCRIPTION, "imageUrl").`as`(ArticleMainCardRecord::writerImgUrl.name),
         ARTICLE_MAIN_CARD.WORKBOOKS.`as`(ArticleMainCardRecord::workbooks.name)
     ).from(ARTICLE_MAIN_CARD)
         .where(ARTICLE_MAIN_CARD.ID.`in`(articleIds))

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/command/ArticleMainCardExcludeWorkbookCommand.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/command/ArticleMainCardExcludeWorkbookCommand.kt
@@ -12,5 +12,6 @@ data class ArticleMainCardExcludeWorkbookCommand(
     val writerId: Long,
     val writerEmail: String,
     val writerName: String,
+    val writerUrl: URL,
     val writerImgUrl: URL,
 )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/record/ArticleMainCardRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/record/ArticleMainCardRecord.kt
@@ -12,6 +12,7 @@ data class ArticleMainCardRecord(
     val writerId: Long,
     val writerEmail: String,
     val writerName: String,
+    val writerUrl: URL,
     val writerImgUrl: URL,
     val workbooks: List<WorkbookRecord> = emptyList(),
 ) {

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/support/ArticleMainCardMapper.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/support/ArticleMainCardMapper.kt
@@ -25,6 +25,7 @@ class ArticleMainCardMapper(
         writerId = record.get(ArticleMainCardRecord::writerId.name, Long::class.java),
         writerEmail = record.get(ArticleMainCardRecord::writerEmail.name, String::class.java),
         writerName = record.get(ArticleMainCardRecord::writerName.name, String::class.java),
+        writerUrl = record.get(ArticleMainCardRecord::writerUrl.name, URL::class.java),
         writerImgUrl = record.get(ArticleMainCardRecord::writerImgUrl.name, URL::class.java),
         workbooks = record.get(ArticleMainCardRecord::workbooks.name, JSON::class.java)?.data()?.let {
             if ("{}".equals(it)) {

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
@@ -42,7 +42,8 @@ class MemberDao(
     fun selectWriterQuery(query: SelectWriterQuery) = dslContext.select(
         Member.MEMBER.ID.`as`(WriterRecord::writerId.name),
         DSL.jsonGetAttributeAsText(Member.MEMBER.DESCRIPTION, "name").`as`(WriterRecord::name.name),
-        DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(WriterRecord::url.name)
+        DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(WriterRecord::url.name),
+        DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "imageUrl").`as`(WriterRecord::imageUrl.name)
     )
         .from(Member.MEMBER)
         .where(Member.MEMBER.ID.eq(query.writerId))

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
@@ -12,7 +12,7 @@ import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
 import com.few.api.repo.dao.member.query.SelectWriterQuery
 import com.few.api.repo.dao.member.query.SelectWritersQuery
 import com.few.api.repo.dao.member.record.MemberIdAndIsDeletedRecord
-import com.few.api.repo.dao.member.record.MemberIdAndNameRecord
+import com.few.api.repo.dao.member.record.MemberRecord
 import com.few.api.repo.dao.member.record.MemberEmailAndTypeRecord
 import com.few.api.repo.dao.member.record.WriterRecord
 import com.few.api.repo.dao.member.record.WriterRecordMappedWorkbook
@@ -22,6 +22,7 @@ import jooq.jooq_dsl.tables.MappingWorkbookArticle
 import jooq.jooq_dsl.tables.Member
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.jooq.impl.DSL.jsonGetAttribute
 import org.jooq.impl.DSL.jsonGetAttributeAsText
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Repository
@@ -127,14 +128,19 @@ class MemberDao(
             .where(Member.MEMBER.TYPE_CD.eq(MemberType.WRITER.code))
             .and(Member.MEMBER.DELETED_AT.isNull)
 
-    fun selectMemberByEmail(query: SelectMemberByEmailQuery): MemberIdAndNameRecord? {
+    fun selectMemberByEmail(query: SelectMemberByEmailQuery): MemberRecord? {
         return selectMemberByEmailQuery(query)
-            .fetchOneInto(MemberIdAndNameRecord::class.java)
+            .fetchOneInto(MemberRecord::class.java)
     }
 
     fun selectMemberByEmailQuery(query: SelectMemberByEmailQuery) = dslContext.select(
-        Member.MEMBER.ID.`as`(MemberIdAndNameRecord::memberId.name),
-        jsonGetAttributeAsText(Member.MEMBER.DESCRIPTION, "name").`as`(MemberIdAndNameRecord::writerName.name) // writer only(nullable)
+        Member.MEMBER.ID.`as`(MemberRecord::memberId.name),
+        // writer only(nullable)
+        jsonGetAttributeAsText(Member.MEMBER.DESCRIPTION, "name").`as`(MemberRecord::writerName.name),
+        // writer only(nullable)
+        jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(MemberRecord::url.name),
+        // writer only(nullable)
+        jsonGetAttribute(Member.MEMBER.DESCRIPTION, "imageUrl").`as`(MemberRecord::imageUrl.name)
     )
         .from(Member.MEMBER)
         .where(Member.MEMBER.EMAIL.eq(query.email))

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
@@ -74,7 +74,8 @@ class MemberDao(
         Member.MEMBER.ID.`as`(WriterRecord::writerId.name),
         DSL.jsonGetAttributeAsText(Member.MEMBER.DESCRIPTION, "name")
             .`as`(WriterRecord::name.name),
-        DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(WriterRecord::url.name)
+        DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "url").`as`(WriterRecord::url.name),
+        DSL.jsonGetAttribute(Member.MEMBER.DESCRIPTION, "imageUrl").`as`(WriterRecord::imageUrl.name)
     )
         .from(Member.MEMBER)
         .where(Member.MEMBER.ID.`in`(notCachedIds))

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/MemberIdAndNameRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/MemberIdAndNameRecord.kt
@@ -1,6 +1,0 @@
-package com.few.api.repo.dao.member.record
-
-data class MemberIdAndNameRecord(
-    val memberId: Long,
-    val writerName: String?,
-)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/MemberRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/MemberRecord.kt
@@ -1,0 +1,10 @@
+package com.few.api.repo.dao.member.record
+
+import java.net.URL
+
+data class MemberRecord(
+    val memberId: Long,
+    val writerName: String?, // writer only
+    val imageUrl: URL?, // writer only
+    val url: URL?, // writer only
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/WriterRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/record/WriterRecord.kt
@@ -6,4 +6,5 @@ data class WriterRecord(
     val writerId: Long,
     val name: String,
     val url: URL,
+    val imageUrl: URL,
 )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/support/WriterDescription.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/support/WriterDescription.kt
@@ -5,4 +5,5 @@ import java.net.URL
 data class WriterDescription(
     val name: String,
     val url: URL,
+    val imageUrl: URL,
 )

--- a/api-repo/src/test/kotlin/com/few/api/repo/dao/member/MemberDaoTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/dao/member/MemberDaoTest.kt
@@ -43,7 +43,11 @@ class MemberDaoTest : JooqTestSpec() {
             .execute()
 
         val writerDescription = writerDescriptionJsonMapper.toJson(
-            WriterDescription("few2", URL("http://localhost:8080/writers/url2"))
+            WriterDescription(
+                "few2",
+                URL("http://localhost:8080/writers/url2"),
+                URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
+            )
         )
 
         dslContext.insertInto(Member.MEMBER)
@@ -100,7 +104,11 @@ class MemberDaoTest : JooqTestSpec() {
     fun setMoreWriters(count: Int) {
         for (i in 3 until 3 + count) {
             val writerDescription = writerDescriptionJsonMapper.toJson(
-                WriterDescription("few$i", URL("http://localhost:8080/writers/url$i"))
+                WriterDescription(
+                    "few$i",
+                    URL("http://localhost:8080/writers/url$i"),
+                    URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
+                )
             )
             dslContext.insertInto(Member.MEMBER)
                 .set(Member.MEMBER.ID, i.toLong())

--- a/api-repo/src/test/kotlin/com/few/api/repo/dao/member/support/CommonJsonMapperTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/dao/member/support/CommonJsonMapperTest.kt
@@ -15,7 +15,8 @@ class CommonJsonMapperTest {
         // Given
         val writerDescription = WriterDescription(
             name = "writer",
-            url = URL("http://localhost:8080/writers/url")
+            url = URL("http://localhost:8080/writers/url"),
+            imageUrl = URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
         )
 
         // When
@@ -34,7 +35,8 @@ class CommonJsonMapperTest {
         val json = """
             {
                 "name": "writer",
-                "url": "http://localhost:8080/writers/url"
+                "url": "http://localhost:8080/writers/url",
+                "imageUrl": "https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742"
             }
         """.trimIndent()
 

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
@@ -47,7 +47,11 @@ class MemberDaoExplainGenerateTest : JooqTestSpec() {
             .execute()
 
         val writerDescription = writerDescriptionJsonMapper.toJson(
-            WriterDescription("few2", URL("http://localhost:8080/writers/url2"))
+            WriterDescription(
+                "few2",
+                URL("http://localhost:8080/writers/url2"),
+                URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
+            )
         )
 
         dslContext.insertInto(Member.MEMBER)

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/service/ArticleMainCardService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/service/ArticleMainCardService.kt
@@ -28,6 +28,7 @@ class ArticleMainCardService(
                 writerId = inDto.writerId,
                 writerEmail = inDto.writerEmail,
                 writerName = inDto.writerName,
+                writerUrl = inDto.writerUrl,
                 writerImgUrl = inDto.writerImgUrl
             )
         )

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/service/dto/InitializeArticleMainCardInDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/service/dto/InitializeArticleMainCardInDto.kt
@@ -12,5 +12,6 @@ data class InitializeArticleMainCardInDto(
     val writerId: Long,
     val writerEmail: String,
     val writerName: String,
+    val writerUrl: URL,
     val writerImgUrl: URL,
 )

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/AddArticleUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/AddArticleUseCase.kt
@@ -27,7 +27,6 @@ import com.few.storage.document.service.PutDocumentService
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.io.File
-import java.net.URL
 import java.time.LocalDateTime
 import java.util.*
 
@@ -46,7 +45,7 @@ class AddArticleUseCase(
     @Transactional
     fun execute(useCaseIn: AddArticleUseCaseIn): AddArticleUseCaseOut {
         /** select writerId */
-        val writerIdRecord = SelectMemberByEmailQuery(useCaseIn.writerEmail).let {
+        val writerRecord = SelectMemberByEmailQuery(useCaseIn.writerEmail).let {
             memberDao.selectMemberByEmail(it)
         } ?: throw NotFoundException("member.notfound.id")
 
@@ -101,7 +100,7 @@ class AddArticleUseCase(
 
         /** insert article */
         val articleMstId = InsertFullArticleRecordCommand(
-            writerId = writerIdRecord.memberId,
+            writerId = writerRecord.memberId,
             mainImageURL = useCaseIn.articleImageUrl,
             title = useCaseIn.title,
             category = category.code,
@@ -141,10 +140,11 @@ class AddArticleUseCase(
                 mainImageUrl = useCaseIn.articleImageUrl,
                 categoryCd = category.code,
                 createdAt = LocalDateTime.now(), // TODO: DB insert 시점으로 변경
-                writerId = writerIdRecord.memberId,
+                writerId = writerRecord.memberId,
                 writerEmail = useCaseIn.writerEmail,
-                writerName = writerIdRecord.writerName ?: throw NotFoundException("article.writer.name"),
-                writerImgUrl = URL("https://github.com/user-attachments/assets/528a6531-2cba-4efc-b8df-64a083d38be8") //TODO: 작가 이미지로 변환
+                writerName = writerRecord.writerName ?: throw NotFoundException("article.writer.name"),
+                writerUrl = writerRecord.url ?: throw NotFoundException("article.writer.url"),
+                writerImgUrl = writerRecord.imageUrl ?: throw NotFoundException("article.writer.url")
             )
         )
 

--- a/api/src/main/kotlin/com/few/api/domain/article/service/ReadArticleWriterRecordService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/ReadArticleWriterRecordService.kt
@@ -18,7 +18,8 @@ class ReadArticleWriterRecordService(
                 ReadWriterOutDto(
                     writerId = it.writerId,
                     name = it.name,
-                    url = it.url
+                    url = it.url,
+                    imageUrl = it.imageUrl
                 )
             }
         }

--- a/api/src/main/kotlin/com/few/api/domain/article/service/dto/ReadWriterOutDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/dto/ReadWriterOutDto.kt
@@ -6,4 +6,5 @@ data class ReadWriterOutDto(
     val writerId: Long,
     val name: String,
     val url: URL,
+    val imageUrl: URL,
 )

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCase.kt
@@ -59,7 +59,8 @@ class ReadArticleUseCase(
             writer = WriterDetail(
                 id = writerRecord.writerId,
                 name = writerRecord.name,
-                url = writerRecord.url
+                url = writerRecord.url,
+                imageUrl = writerRecord.imageUrl
             ),
             mainImageUrl = articleRecord.mainImageURL,
             title = articleRecord.title,

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticlesUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticlesUseCase.kt
@@ -81,7 +81,8 @@ class ReadArticlesUseCase(
                 writer = WriterDetail(
                     id = a.writerId,
                     name = a.writerName,
-                    url = a.writerImgUrl
+                    imageUrl = a.writerImgUrl,
+                    url = a.writerUrl
                 ),
                 mainImageUrl = a.mainImageUrl,
                 title = a.articleTitle,

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleUseCaseOut.kt
@@ -20,6 +20,7 @@ data class WriterDetail(
     val id: Long,
     val name: String,
     val url: URL,
+    val imageUrl: URL,
 )
 
 data class WorkbookDetail(

--- a/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
@@ -39,9 +39,10 @@ class ArticleController(
             id = useCaseOut.id,
             title = useCaseOut.title,
             writer = WriterInfo(
-                useCaseOut.writer.id,
-                useCaseOut.writer.name,
-                useCaseOut.writer.url
+                id = useCaseOut.writer.id,
+                name = useCaseOut.writer.name,
+                url = useCaseOut.writer.url,
+                imageUrl = useCaseOut.writer.imageUrl
             ),
             mainImageUrl = useCaseOut.mainImageUrl,
             content = useCaseOut.content,
@@ -72,9 +73,10 @@ class ArticleController(
                 id = a.id,
                 title = a.title,
                 writer = WriterInfo(
-                    a.writer.id,
-                    a.writer.name,
-                    a.writer.url
+                    id = a.writer.id,
+                    name = a.writer.name,
+                    url = a.writer.url,
+                    imageUrl = a.writer.imageUrl
                 ),
                 mainImageUrl = a.mainImageUrl,
                 content = a.content,

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
@@ -22,6 +22,7 @@ data class WriterInfo(
     val id: Long,
     val name: String,
     val url: URL,
+    val imageUrl: URL,
 )
 
 data class WorkbookInfo(

--- a/api/src/test/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCaseTest.kt
@@ -57,7 +57,8 @@ class ReadArticleUseCaseTest : BehaviorSpec({
             val writerSvcOutDto = ReadWriterOutDto(
                 writerId = 1L,
                 name = "hunca",
-                url = URL("https://jh-labs.tistory.com/")
+                url = URL("https://jh-labs.tistory.com/"),
+                imageUrl = URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
             )
             val probSvcOutDto = BrowseArticleProblemsOutDto(problemIds = listOf(1, 2, 3))
 

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -78,7 +78,8 @@ class ArticleControllerTest : ControllerTestSpec() {
                 writer = WriterDetail(
                     id = 1L,
                     name = "안나포",
-                    url = URL("http://localhost:8080/api/v1/writers/1")
+                    url = URL("http://localhost:8080/api/v1/writers/1"),
+                    imageUrl = URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
                 ),
                 mainImageUrl = URL("https://github.com/YAPP-Github/24th-Web-Team-1-BE/assets/102807742/0643d805-5f3a-4563-8c48-2a7d51795326"),
                 title = "ETF(상장 지수 펀드)란? 모르면 손해라고?",
@@ -115,6 +116,8 @@ class ArticleControllerTest : ControllerTestSpec() {
                                             .fieldWithString("아티클 작가 이름"),
                                         PayloadDocumentation.fieldWithPath("data.writer.url")
                                             .fieldWithString("아티클 작가 링크"),
+                                        PayloadDocumentation.fieldWithPath("data.writer.imageUrl")
+                                            .fieldWithString("아티클 작가 이미지 링크(non-null)"),
                                         PayloadDocumentation.fieldWithPath("data.mainImageUrl")
                                             .fieldWithString("아티클 썸네일 이미지 링크"),
                                         PayloadDocumentation.fieldWithPath("data.title")
@@ -161,7 +164,8 @@ class ArticleControllerTest : ControllerTestSpec() {
                         writer = WriterDetail(
                             id = 1L,
                             name = "안나포",
-                            url = URL("http://localhost:8080/api/v1/writers/1")
+                            url = URL("http://localhost:8080/api/v1/writers/1"),
+                            imageUrl = URL("https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742")
                         ),
                         mainImageUrl = URL("https://github.com/YAPP-Github/24th-Web-Team-1-BE/assets/102807742/0643d805-5f3a-4563-8c48-2a7d51795326"),
                         title = "ETF(상장 지수 펀드)란? 모르면 손해라고?",
@@ -218,6 +222,8 @@ class ArticleControllerTest : ControllerTestSpec() {
                                             .fieldWithString("아티클 작가 이름"),
                                         PayloadDocumentation.fieldWithPath("data.articles[].writer.url")
                                             .fieldWithString("아티클 작가 링크"),
+                                        PayloadDocumentation.fieldWithPath("data.articles[].writer.imageUrl")
+                                            .fieldWithString("아티클 작가 이미지 링크(non-null)"),
                                         PayloadDocumentation.fieldWithPath("data.articles[].mainImageUrl")
                                             .fieldWithString("아티클 썸네일 이미지 링크"),
                                         PayloadDocumentation.fieldWithPath("data.articles[].title")


### PR DESCRIPTION
🎫 연관 이슈
---
resolved #293 

💁‍♂️ PR 내용
----

🙏 작업
----
**_NOTE - 추후 작가 추가 API 추가될 때 디폴트 이미지 넣는 코드 들어가야 합니다_**

🙈 PR 참고 사항
----
## 보정쿼리
- 현재 Member, article_main_card 테이블의 description, writer_description 제이슨 컬럼에 'imageUrl' 필드를 추가해 줘야 함

### 1. Member 테이블 보정
```SQL
-- 보정 쿼리
WITH random_url AS (
    SELECT 'https://github.com/user-attachments/assets/28df9078-488c-49d6-9375-54ce5a250742' AS value
    UNION ALL
    SELECT 'https://github.com/user-attachments/assets/385dcafd-6737-41d7-aaa0-9db4ea6f27ea'
    UNION ALL
    SELECT 'https://github.com/user-attachments/assets/209da8ff-7c78-41b7-8e3e-40a2705f714a'
)
UPDATE MEMBER
SET description = JSON_SET(description, '$.imageUrl', 
    (SELECT value FROM random_url ORDER BY RAND() LIMIT 1))
where type_cd = 120;
```

### 2. article_main_card 테이블 보정
```SQL
UPDATE ARTICLE_MAIN_CARD a
JOIN MEMBER m ON a.writer_id = m.id
SET a.writer_description = m.description
WHERE a.writer_id = m.id;
```

📸 스크린샷
----
### 1. Member 테이블 보정 테스트
- as-is
![image](https://github.com/user-attachments/assets/b8c07bf3-a5a3-4c34-b2e2-8fbc46f09394)

- to-be
![image](https://github.com/user-attachments/assets/e5185060-51b6-4155-ba45-85d8327d40bb)


### 2. article_main_card 테이블 보정 테스트
![image](https://github.com/user-attachments/assets/73841aa5-fead-42cc-850c-d1895fed36df)


----

## API-test
### 아티클 신규 저장 후 article_main_card 테이블 확인
![image](https://github.com/user-attachments/assets/5231abe8-5186-4901-ae2d-e3a8c890de83)
- imageUrl 정상 저장 확인
- 
### 아티클 목록 조회
<img width="564" alt="image" src="https://github.com/user-attachments/assets/77127638-98bf-4ad4-867e-8d8f34f267fc">

### 아티클 단건 조회
<img width="538" alt="image" src="https://github.com/user-attachments/assets/a968c393-4d24-49cc-8f14-974289c2c025">


🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
