### PR TITLE
[#298/refactor]: 가입/인증에 따라 다른 내용 채워서 이메일 보내도록 수정

### DIFF
--- a/email/src/main/kotlin/com/few/email/service/member/SendAuthEmailService.kt
+++ b/email/src/main/kotlin/com/few/email/service/member/SendAuthEmailService.kt
@@ -20,6 +20,8 @@ class SendAuthEmailService(
         val context = Context()
         context.setVariable("email", args.content.email)
         context.setVariable("confirmLink", args.content.confirmLink)
+        context.setVariable("headComment", args.content.headComment)
+        context.setVariable("subComment", args.content.subComment)
         return templateEngine.process(args.template, context)
     }
 }

--- a/email/src/main/kotlin/com/few/email/service/member/dto/SendAuthEmailArgs.kt
+++ b/email/src/main/kotlin/com/few/email/service/member/dto/SendAuthEmailArgs.kt
@@ -12,6 +12,8 @@ data class SendAuthEmailArgs(
 ) : SendMailArgs<Content, String>
 
 data class Content(
+    val headComment: String,
+    val subComment: String,
     val email: String,
     val confirmLink: URL,
 )

--- a/email/src/main/resources/templates/auth.html
+++ b/email/src/main/resources/templates/auth.html
@@ -99,7 +99,7 @@
     <tr>
         <td>
             <header>
-                <h2 class="h2-bold" style="color: black; padding: 5px;">few에 가입해주셔서 감사합니다.</h2>
+                <h2 class="h2-bold" style="color: black; padding: 5px;" th:text="${headComment}"></h2>
             </header>
         </td>
     </tr>
@@ -107,7 +107,7 @@
     <tr>
         <td>
             <article>
-                <span class="body2-regular" style="color: #484848">가입하신 이메일 주소를 확인해주세요.</span>
+                <span class="body2-regular" style="color: #484848" th:text="${subComment}"></span>
                 <br>
                 <span class="body2-medium" style="color: #0166B3" id="email" th:text="${email}"></span>
             </article>


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #298 

💁‍♂️ PR 내용
----
- 가입/인증에 따라 다른 내용 채워서 이메일 보내도록 수정

🙏 작업
----
- 가입/인증에 따라 다른 내용 채워서 이메일 보내도록 수정

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
