### PR TITLE
[Feat/#310] 이미지 Webp 변환 코드 구현

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -19,6 +19,11 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:${DependencyVersion.JWT}")
     implementation("io.jsonwebtoken:jjwt-jackson:${DependencyVersion.JWT}")
 
+    /** scrimage */
+    implementation("com.sksamuel.scrimage:scrimage-core:${DependencyVersion.SCRIMAGE}")
+    /** for convert to webp */
+    implementation("com.sksamuel.scrimage:scrimage-webp:${DependencyVersion.SCRIMAGE}")
+
     /** swagger & restdocs */
     implementation("org.springdoc:springdoc-openapi-ui:${DependencyVersion.SPRINGDOC}")
     implementation("org.springframework.restdocs:spring-restdocs-webtestclient")

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/PutImageUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/PutImageUseCase.kt
@@ -64,6 +64,6 @@ class PutImageUseCase(
             } ?: throw ExternalIntegrationException("external.presignedfail.image")
 
         // todo fix if webp is default
-        return PutImageUseCaseOut(url)
+        return PutImageUseCaseOut(url, listOf(suffix, "webp"))
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/dto/PutImageUseCaseOut.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/dto/PutImageUseCaseOut.kt
@@ -4,4 +4,5 @@ import java.net.URL
 
 data class PutImageUseCaseOut(
     val url: URL,
+    val supportSuffix: List<String>,
 )

--- a/api/src/main/kotlin/com/few/api/web/controller/admin/AdminController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/admin/AdminController.kt
@@ -113,7 +113,7 @@ class AdminController(
             putImageUseCase.execute(useCaseIn)
         }
 
-        return ImageSourceResponse(useCaseOut.url).let {
+        return ImageSourceResponse(useCaseOut.url, useCaseOut.supportSuffix).let {
             ApiResponseGenerator.success(it, HttpStatus.OK)
         }
     }

--- a/api/src/main/kotlin/com/few/api/web/controller/admin/response/ImageSourceResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/admin/response/ImageSourceResponse.kt
@@ -4,4 +4,5 @@ import java.net.URL
 
 data class ImageSourceResponse(
     val url: URL,
+    val supportSuffix: List<String>,
 )

--- a/api/src/test/kotlin/com/few/api/web/controller/admin/AdminControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/admin/AdminControllerTest.kt
@@ -315,8 +315,8 @@ class AdminControllerTest : ControllerTestSpec() {
         val api = "PutImage"
         val uri = UriComponentsBuilder.newInstance().path("$BASE_URL/utilities/conversion/image").build().toUriString()
         val request = ImageSourceRequest(source = MockMultipartFile("source", "test.jpg", "image/jpeg", "test".toByteArray()))
-        val response = ImageSourceResponse(URL("http://localhost:8080/test.jpg"))
-        val useCaseOut = PutImageUseCaseOut(response.url)
+        val response = ImageSourceResponse(URL("http://localhost:8080/test.jpg"), listOf("jpg", "webp"))
+        val useCaseOut = PutImageUseCaseOut(response.url, response.supportSuffix)
         val useCaseIn = PutImageUseCaseIn(request.source)
         `when`(putImageUseCase.execute(useCaseIn)).thenReturn(useCaseOut)
 
@@ -344,6 +344,10 @@ class AdminControllerTest : ControllerTestSpec() {
                                         PayloadDocumentation.fieldWithPath("data.url")
                                             .fieldWithString(
                                                 "이미지 URL"
+                                            ),
+                                        PayloadDocumentation.fieldWithPath("data.supportSuffix")
+                                            .fieldWithArray(
+                                                "지원하는 확장자"
                                             )
                                     )
                                 )

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -14,6 +14,9 @@ object DependencyVersion {
     /** jwt */
     const val JWT = "0.11.5"
 
+    /** scrimage */
+    const val SCRIMAGE = "4.1.2"
+
     /** flyway */
     const val FLYWAY = "9.16.0"
 


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #310 

💁‍♂️ PR 내용
----
- 이미지 Webp 변환 코드 구현

🙏 작업
----
- sksamuel라는 의존성을 통해 이미지 webp 변환 구현
- webp로 변환한 파일 역시 동일한 이름 + webp 확장자로 s3 및 imageIfo에 저장합니다.
- 우선 기본 응답 url은 내려줍니다. 대신 지원하는 확장자를 응답에 추가하여주었습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----
<img width="1704" alt="스크린샷 2024-08-06 오후 8 43 57" src="https://github.com/user-attachments/assets/bd740a89-a306-4820-8228-b28f07983d84">

확장자만 다르게 동일한 파일이 들어가는 것 확인하였습니다.

<img width="1718" alt="스크린샷 2024-08-06 오후 9 06 16" src="https://github.com/user-attachments/assets/3f67c584-841a-407f-82f5-255bb215d333">

변경된 응답 

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
