### PR TITLE
[Refactor/#358] 아티클 읽음 기록 이벤트 처리로 리펙토링

### DIFF
--- a/api/src/main/kotlin/com/few/api/domain/article/event/ReadArticleEventListener.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/event/ReadArticleEventListener.kt
@@ -1,0 +1,17 @@
+package com.few.api.domain.article.event
+
+import com.few.api.domain.article.event.dto.ReadArticleEvent
+import com.few.api.domain.article.handler.ArticleViewHisAsyncHandler
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class ReadArticleEventListener(
+    private val articleViewHisAsyncHandler: ArticleViewHisAsyncHandler,
+) {
+
+    @EventListener
+    fun handleEvent(event: ReadArticleEvent) {
+        articleViewHisAsyncHandler.addArticleViewHis(event.articleId, event.memberId, event.category)
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/article/event/dto/ReadArticleEvent.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/event/dto/ReadArticleEvent.kt
@@ -1,0 +1,9 @@
+package com.few.api.domain.article.event.dto
+
+import com.few.data.common.code.CategoryType
+
+data class ReadArticleEvent(
+    val articleId: Long,
+    val memberId: Long,
+    val category: CategoryType,
+)

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/BrowseArticlesUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/BrowseArticlesUseCase.kt
@@ -17,7 +17,7 @@ import java.util.*
 import kotlin.Comparator
 
 @Component
-class ReadArticlesUseCase(
+class BrowseArticlesUseCase(
     private val articleViewCountDao: ArticleViewCountDao,
     private val articleMainCardDao: ArticleMainCardDao,
     private val articleDao: ArticleDao,

--- a/api/src/main/kotlin/com/few/api/domain/workbook/article/usecase/ReadWorkBookArticleUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/article/usecase/ReadWorkBookArticleUseCase.kt
@@ -58,12 +58,6 @@ class ReadWorkBookArticleUseCase(
             )
         )
 
-        /**
-         * NOTE: The articleViewHisAsyncHandler creates a new transaction that is separate from the current context.
-         * So this section, the logic after the articleViewHisAsyncHandler call,
-         * is where the mismatch between the two transactions can occur if an exception is thrown.
-         */
-
         return ReadWorkBookArticleOut(
             id = articleRecord.articleId,
             writer = WriterDetail(

--- a/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/ArticleController.kt
@@ -1,7 +1,7 @@
 package com.few.api.web.controller.article
 
 import com.few.api.domain.article.usecase.ReadArticleUseCase
-import com.few.api.domain.article.usecase.ReadArticlesUseCase
+import com.few.api.domain.article.usecase.BrowseArticlesUseCase
 import com.few.api.domain.article.usecase.dto.ReadArticleUseCaseIn
 import com.few.api.domain.article.usecase.dto.ReadArticlesUseCaseIn
 import com.few.api.security.filter.token.AccessTokenResolver
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping(value = ["/api/v1/articles"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ArticleController(
     private val readArticleUseCase: ReadArticleUseCase,
-    private val readArticlesUseCase: ReadArticlesUseCase,
+    private val browseArticlesUseCase: BrowseArticlesUseCase,
     private val tokenResolver: TokenResolver,
 ) {
 
@@ -81,7 +81,7 @@ class ArticleController(
             defaultValue = "-1"
         ) categoryCd: Byte,
     ): ApiResponse<ApiResponse.SuccessBody<ReadArticlesResponse>> {
-        val useCaseOut = readArticlesUseCase.execute(ReadArticlesUseCaseIn(prevArticleId, categoryCd))
+        val useCaseOut = browseArticlesUseCase.execute(ReadArticlesUseCaseIn(prevArticleId, categoryCd))
 
         val articles: List<ReadArticleResponse> = useCaseOut.articles.map { a ->
             ReadArticleResponse(

--- a/api/src/test/kotlin/com/few/api/web/controller/ControllerTestSpec.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/ControllerTestSpec.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.few.api.ApiMain
 import com.few.api.domain.admin.document.usecase.*
 import com.few.api.domain.article.usecase.ReadArticleUseCase
-import com.few.api.domain.article.usecase.ReadArticlesUseCase
+import com.few.api.domain.article.usecase.BrowseArticlesUseCase
 import com.few.api.domain.log.AddApiLogUseCase
 import com.few.api.domain.member.usecase.SaveMemberUseCase
 import com.few.api.domain.member.usecase.TokenUseCase
@@ -73,7 +73,7 @@ abstract class ControllerTestSpec {
     lateinit var readArticleUseCase: ReadArticleUseCase
 
     @MockBean
-    lateinit var readArticlesUseCase: ReadArticlesUseCase
+    lateinit var browseArticlesUseCase: BrowseArticlesUseCase
 
     /** MemberControllerTest */
     @MockBean

--- a/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
+++ b/api/src/test/kotlin/com/few/api/web/controller/article/ArticleControllerTest.kt
@@ -169,7 +169,7 @@ class ArticleControllerTest : ControllerTestSpec() {
             }.toList(),
             true
         )
-        `when`(readArticlesUseCase.execute(useCaseIn)).thenReturn(useCaseOut)
+        `when`(browseArticlesUseCase.execute(useCaseIn)).thenReturn(useCaseOut)
 
         // when
         mockMvc.perform(


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #358 

💁‍♂️ PR 내용
----
- 아티클 읽음 기록 이벤트 처리로 리펙토링
-  ReadArticlesUseCase -> BrowseArticlesUseCase로 컨벤션 통일

🙏 작업
----
- ReadArticleEvent 생성 및 처리

🙈 PR 참고 사항
----

📸 스크린샷
----
<img width="1728" alt="스크린샷 2024-08-26 오후 4 23 24" src="https://github.com/user-attachments/assets/1c11598a-d3fd-41f3-bf7a-805897db1a1a">

이벤트 리스너까지는 동기로 이후 이벤트 처리는 비동기로 처리하였는데 스레드 및 트렌잭션이 분리되어 있는 것을 확인하였습니다.

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
