### PR TITLE
[Refactor/#360] 구독과 동시에 아티클 전송할 수 있도록 수정

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/query/SelectArticleContentQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/query/SelectArticleContentQuery.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.article.query
+
+data class SelectArticleContentQuery(
+    val articleId: Long,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/article/record/ArticleContentRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/article/record/ArticleContentRecord.kt
@@ -1,0 +1,12 @@
+package com.few.api.repo.dao.article.record
+
+import java.net.URL
+
+data class ArticleContentRecord(
+    val id: Long,
+    val category: String,
+    val articleTitle: String,
+    val articleContent: String,
+    val writerName: String,
+    val writerLink: URL,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/MemberDao.kt
@@ -4,13 +4,9 @@ import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
 import com.few.api.repo.config.LocalCacheConfig.Companion.SELECT_WRITER_CACHE
 import com.few.api.repo.dao.member.command.DeleteMemberCommand
 import com.few.api.repo.dao.member.command.InsertMemberCommand
-import com.few.api.repo.dao.member.query.BrowseWorkbookWritersQuery
 import com.few.api.repo.dao.member.command.UpdateDeletedMemberTypeCommand
 import com.few.api.repo.dao.member.command.UpdateMemberTypeCommand
-import com.few.api.repo.dao.member.query.SelectMemberByEmailNotConsiderDeletedAtQuery
-import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
-import com.few.api.repo.dao.member.query.SelectWriterQuery
-import com.few.api.repo.dao.member.query.SelectWritersQuery
+import com.few.api.repo.dao.member.query.*
 import com.few.api.repo.dao.member.record.MemberIdAndIsDeletedRecord
 import com.few.api.repo.dao.member.record.MemberRecord
 import com.few.api.repo.dao.member.record.MemberEmailAndTypeRecord
@@ -170,6 +166,17 @@ class MemberDao(
         dslContext.insertInto(Member.MEMBER)
             .set(Member.MEMBER.EMAIL, command.email)
             .set(Member.MEMBER.TYPE_CD, command.memberType.code)
+
+    fun selectMemberEmail(query: SelectMemberEmailQuery): String? {
+        return selectMemberEmailQuery(query)
+            .fetchOne()
+            ?.value1()
+    }
+
+    fun selectMemberEmailQuery(query: SelectMemberEmailQuery) = dslContext.select(Member.MEMBER.EMAIL)
+        .from(Member.MEMBER)
+        .where(Member.MEMBER.ID.eq(query.memberId))
+        .and(Member.MEMBER.DELETED_AT.isNull)
 
     fun selectMemberEmailAndType(memberId: Long): MemberEmailAndTypeRecord? {
         return selectMemberIdAndTypeQuery(memberId)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/member/query/SelectMemberEmailQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/member/query/SelectMemberEmailQuery.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.member.query
+
+data class SelectMemberEmailQuery(
+    val memberId: Long,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
@@ -1,8 +1,6 @@
 package com.few.api.repo.dao.subscription
 
-import com.few.api.repo.dao.subscription.command.InsertWorkbookSubscriptionCommand
-import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInAllSubscriptionCommand
-import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInWorkbookSubscriptionCommand
+import com.few.api.repo.dao.subscription.command.*
 import com.few.api.repo.dao.subscription.query.*
 import com.few.api.repo.dao.subscription.record.WorkbookSubscriptionStatus
 import com.few.api.repo.dao.subscription.record.CountAllSubscriptionStatusRecord
@@ -163,4 +161,28 @@ class SubscriptionDao(
         .from(SUBSCRIPTION)
         .groupBy(SUBSCRIPTION.TARGET_WORKBOOK_ID)
         .query
+
+    fun updateArticleProgress(command: UpdateArticleProgressCommand) {
+        updateArticleProgressCommand(command)
+            .execute()
+    }
+
+    fun updateArticleProgressCommand(
+        command: UpdateArticleProgressCommand,
+    ) = dslContext.update(SUBSCRIPTION)
+        .set(SUBSCRIPTION.PROGRESS, SUBSCRIPTION.PROGRESS.add(1))
+        .where(SUBSCRIPTION.MEMBER_ID.eq(command.memberId))
+        .and(SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(command.workbookId))
+
+    fun updateLastArticleProgress(command: UpdateLastArticleProgressCommand) {
+        updateLastArticleProgressCommand(command)
+            .execute()
+    }
+
+    fun updateLastArticleProgressCommand(command: UpdateLastArticleProgressCommand) =
+        dslContext.update(SUBSCRIPTION)
+            .set(SUBSCRIPTION.DELETED_AT, LocalDateTime.now())
+            .set(SUBSCRIPTION.UNSUBS_OPINION, command.opinion)
+            .where(SUBSCRIPTION.MEMBER_ID.eq(command.memberId))
+            .and(SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(command.workbookId))
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/command/UpdateArticleProgressCommand.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/command/UpdateArticleProgressCommand.kt
@@ -1,0 +1,6 @@
+package com.few.api.repo.dao.subscription.command
+
+data class UpdateArticleProgressCommand(
+    val memberId: Long,
+    val workbookId: Long,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/command/UpdateLastArticleProgressCommand.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/command/UpdateLastArticleProgressCommand.kt
@@ -1,0 +1,7 @@
+package com.few.api.repo.dao.subscription.command
+
+data class UpdateLastArticleProgressCommand(
+    val memberId: Long,
+    val workbookId: Long,
+    val opinion: String = "receive.all",
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
@@ -5,6 +5,7 @@ import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
 import com.few.api.repo.dao.workbook.command.MapWorkBookToArticleCommand
 import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
+import com.few.api.repo.dao.workbook.query.SelectWorkBookLastArticleIdQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import com.few.api.repo.dao.workbook.record.SelectWorkBookRecord
 import com.few.api.repo.dao.workbook.record.SelectWorkBookRecordWithSubscriptionCount
@@ -129,4 +130,18 @@ class WorkbookDao(
             else -> Workbook.WORKBOOK.CATEGORY_CD.eq(query.category)
         }
     }
+
+    fun selectWorkBookLastArticleId(query: SelectWorkBookLastArticleIdQuery): Long? {
+        return selectWorkBookLastArticleIdQuery(query)
+            .fetchOneInto(Long::class.java)
+    }
+
+    fun selectWorkBookLastArticleIdQuery(query: SelectWorkBookLastArticleIdQuery) =
+        dslContext.select(
+            DSL.max(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DAY_COL)
+        )
+            .from(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE)
+            .where(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.WORKBOOK_ID.eq(query.workbookId))
+            .and(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.DELETED_AT.isNull)
+            .groupBy(MappingWorkbookArticle.MAPPING_WORKBOOK_ARTICLE.WORKBOOK_ID)
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/query/SelectWorkBookLastArticleIdQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/query/SelectWorkBookLastArticleIdQuery.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.workbook.query
+
+data class SelectWorkBookLastArticleIdQuery(
+    val workbookId: Long,
+)

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
@@ -5,10 +5,7 @@ import com.few.api.repo.dao.member.command.DeleteMemberCommand
 import com.few.api.repo.dao.member.command.InsertMemberCommand
 import com.few.api.repo.dao.member.command.UpdateDeletedMemberTypeCommand
 import com.few.api.repo.dao.member.command.UpdateMemberTypeCommand
-import com.few.api.repo.dao.member.query.BrowseWorkbookWritersQuery
-import com.few.api.repo.dao.member.query.SelectMemberByEmailNotConsiderDeletedAtQuery
-import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
-import com.few.api.repo.dao.member.query.SelectWriterQuery
+import com.few.api.repo.dao.member.query.*
 import com.few.api.repo.dao.member.support.WriterDescriptionJsonMapper
 import com.few.api.repo.explain.ExplainGenerator
 import com.few.api.repo.explain.InsertUpdateExplainGenerator

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/member/MemberDaoExplainGenerateTest.kt
@@ -5,10 +5,7 @@ import com.few.api.repo.dao.member.command.DeleteMemberCommand
 import com.few.api.repo.dao.member.command.InsertMemberCommand
 import com.few.api.repo.dao.member.command.UpdateDeletedMemberTypeCommand
 import com.few.api.repo.dao.member.command.UpdateMemberTypeCommand
-import com.few.api.repo.dao.member.query.BrowseWorkbookWritersQuery
-import com.few.api.repo.dao.member.query.SelectMemberByEmailNotConsiderDeletedAtQuery
-import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
-import com.few.api.repo.dao.member.query.SelectWriterQuery
+import com.few.api.repo.dao.member.query.*
 import com.few.api.repo.dao.member.support.WriterDescription
 import com.few.api.repo.dao.member.support.WriterDescriptionJsonMapper
 import com.few.api.repo.explain.InsertUpdateExplainGenerator
@@ -140,6 +137,17 @@ class MemberDaoExplainGenerateTest : JooqTestSpec() {
         val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
 
         ResultGenerator.execute(command, explain, "insertMemberCommandExplain")
+    }
+
+    @Test
+    fun selectMemberEmailQueryExplain() {
+        val query = SelectMemberEmailQuery(1).let {
+            memberDao.selectMemberEmailQuery(it)
+        }
+
+        val explain = ExplainGenerator.execute(dslContext, query)
+
+        ResultGenerator.execute(query, explain, "selectMemberEmailQueryExplain")
     }
 
     @Test

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
@@ -1,9 +1,7 @@
 package com.few.api.repo.explain.subscription
 
 import com.few.api.repo.dao.subscription.SubscriptionDao
-import com.few.api.repo.dao.subscription.command.InsertWorkbookSubscriptionCommand
-import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInAllSubscriptionCommand
-import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInWorkbookSubscriptionCommand
+import com.few.api.repo.dao.subscription.command.*
 import com.few.api.repo.dao.subscription.query.CountWorkbookMappedArticlesQuery
 import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookActiveSubscription
 import com.few.api.repo.dao.subscription.query.SelectAllWorkbookSubscriptionStatusNotConsiderDeletedAtQuery
@@ -166,5 +164,29 @@ class SubscriptionDaoExplainGenerateTest : JooqTestSpec() {
         val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
 
         ResultGenerator.execute(command, explain, "updateDeletedAtInWorkbookSubscriptionCommandExplain")
+    }
+
+    @Test
+    fun updateArticleProgressCommandExplain() {
+        val command = UpdateArticleProgressCommand(1L, 1L)
+            .let {
+                subscriptionDao.updateArticleProgressCommand(it)
+            }
+
+        val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
+
+        ResultGenerator.execute(command, explain, "updateArticleProgressCommandExplain")
+    }
+
+    @Test
+    fun updateLastArticleProgressCommandExplain() {
+        val command = UpdateLastArticleProgressCommand(1L, 1L)
+            .let {
+                subscriptionDao.updateLastArticleProgressCommand(it)
+            }
+
+        val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
+
+        ResultGenerator.execute(command, explain, "updateLastArticleProgressCommandExplain")
     }
 }

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/workbook/WorkbookDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/workbook/WorkbookDaoExplainGenerateTest.kt
@@ -4,6 +4,7 @@ import com.few.api.repo.dao.workbook.WorkbookDao
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
 import com.few.api.repo.dao.workbook.command.MapWorkBookToArticleCommand
 import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
+import com.few.api.repo.dao.workbook.query.SelectWorkBookLastArticleIdQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import com.few.api.repo.explain.InsertUpdateExplainGenerator
 import com.few.api.repo.explain.ResultGenerator
@@ -104,5 +105,16 @@ class WorkbookDaoExplainGenerateTest : JooqTestSpec() {
         val explain = InsertUpdateExplainGenerator.execute(dslContext, command.sql, command.bindValues)
 
         ResultGenerator.execute(command, explain, "mapWorkBookToArticleCommandExplain")
+    }
+
+    @Test
+    fun selectWorkBookLastArticleIdQueryExplain() {
+        val query = SelectWorkBookLastArticleIdQuery(1L).let {
+            workbookDao.selectWorkBookLastArticleIdQuery(it)
+        }
+
+        val explain = ExplainGenerator.execute(dslContext, query)
+
+        ResultGenerator.execute(query, explain, "selectWorkBookLastArticleIdQueryExplain")
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/event/WorkbookSubscriptionAfterCompletionEventListener.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/event/WorkbookSubscriptionAfterCompletionEventListener.kt
@@ -1,0 +1,25 @@
+package com.few.api.domain.subscription.event
+
+import com.few.api.domain.subscription.event.dto.WorkbookSubscriptionEvent
+import com.few.api.domain.subscription.handler.SendWorkbookArticleAsyncHandler
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class WorkbookSubscriptionAfterCompletionEventListener(
+    private val sendWorkbookArticleAsyncHandler: SendWorkbookArticleAsyncHandler,
+) {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun handleEvent(event: WorkbookSubscriptionEvent) {
+        sendWorkbookArticleAsyncHandler.sendWorkbookArticle(
+            event.memberId,
+            event.workbookId,
+            event.articleDayCol.toByte()
+        )
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/event/WorkbookSubscriptionEventListener.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/event/WorkbookSubscriptionEventListener.kt
@@ -1,39 +1,17 @@
 package com.few.api.domain.subscription.event
 
-import com.few.api.client.subscription.SubscriptionClient
-import com.few.api.client.subscription.dto.WorkbookSubscriptionArgs
-import com.few.api.config.ApiThreadPoolConfig.Companion.DISCORD_HOOK_EVENT_POOL
 import com.few.api.domain.subscription.event.dto.WorkbookSubscriptionEvent
-import com.few.api.domain.subscription.service.WorkbookService
-import com.few.api.domain.subscription.service.dto.ReadWorkbookTitleInDto
-import com.few.api.exception.common.NotFoundException
-import com.few.api.repo.dao.subscription.SubscriptionDao
+import com.few.api.domain.subscription.handler.WorkbookSubscriptionClientAsyncHandler
 import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 @Component
 class WorkbookSubscriptionEventListener(
-    private val subscriptionDao: SubscriptionDao,
-    private val subscriptionClient: SubscriptionClient,
-    private val workbookService: WorkbookService,
+    private val workbookSubscriptionClientAsyncHandler: WorkbookSubscriptionClientAsyncHandler,
 ) {
 
-    @Async(value = DISCORD_HOOK_EVENT_POOL)
     @EventListener
-    fun handleWorkbookSubscriptionEvent(event: WorkbookSubscriptionEvent) {
-        val title = ReadWorkbookTitleInDto(event.workbookId).let { dto ->
-            workbookService.readWorkbookTitle(dto)?.workbookTitle
-                ?: throw NotFoundException("workbook.notfound.id")
-        }
-        subscriptionDao.countAllSubscriptionStatus().let { record ->
-            WorkbookSubscriptionArgs(
-                totalSubscriptions = record.totalSubscriptions,
-                activeSubscriptions = record.activeSubscriptions,
-                workbookTitle = title
-            ).let { args ->
-                subscriptionClient.announceWorkbookSubscription(args)
-            }
-        }
+    fun handleEvent(event: WorkbookSubscriptionEvent) {
+        workbookSubscriptionClientAsyncHandler.sendSubscriptionEvent(event.workbookId)
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/event/dto/WorkbookSubscriptionEvent.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/event/dto/WorkbookSubscriptionEvent.kt
@@ -1,5 +1,7 @@
 package com.few.api.domain.subscription.event.dto
 
 data class WorkbookSubscriptionEvent(
+    val memberId: Long,
     val workbookId: Long,
+    val articleDayCol: Int,
 )

--- a/api/src/main/kotlin/com/few/api/domain/subscription/handler/SendWorkbookArticleAsyncHandler.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/handler/SendWorkbookArticleAsyncHandler.kt
@@ -1,0 +1,80 @@
+package com.few.api.domain.subscription.handler
+
+import com.few.api.config.DatabaseAccessThreadPoolConfig.Companion.DATABASE_ACCESS_POOL
+import com.few.api.domain.subscription.service.SubscriptionArticleService
+import com.few.api.domain.subscription.service.SubscriptionMemberService
+import com.few.api.domain.subscription.service.SubscriptionEmailService
+import com.few.api.domain.subscription.service.SubscriptionWorkbookService
+import com.few.api.domain.subscription.service.dto.*
+import com.few.api.exception.common.NotFoundException
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import com.few.api.repo.dao.subscription.command.UpdateArticleProgressCommand
+import com.few.api.repo.dao.subscription.command.UpdateLastArticleProgressCommand
+import com.few.data.common.code.CategoryType
+import com.few.email.service.article.dto.Content
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class SendWorkbookArticleAsyncHandler(
+    private val memberService: SubscriptionMemberService,
+    private val articleService: SubscriptionArticleService,
+    private val workbookService: SubscriptionWorkbookService,
+    private val subscriptionDao: SubscriptionDao,
+    private val emailService: SubscriptionEmailService,
+) {
+
+    @Async(value = DATABASE_ACCESS_POOL)
+    fun sendWorkbookArticle(memberId: Long, workbookId: Long, articleDayCol: Byte) {
+        val date = LocalDate.now()
+        val memberEmail = ReadMemberEmailInDto(memberId).let { memberService.readMemberEmail(it) }.let { it?.email }
+            ?: throw NotFoundException("member.notfound.id")
+        val article = ReadArticleIdByWorkbookIdAndDayDto(workbookId, articleDayCol.toInt()).let {
+            articleService.readArticleIdByWorkbookIdAndDay(it)
+        }?.let { articleId ->
+            ReadArticleContentInDto(articleId).let {
+                articleService.readArticleContent(it)
+            }
+        } ?: throw NotFoundException("article.notfound.id")
+
+        SendArticleInDto(
+            memberId = memberId,
+            workbookId = workbookId,
+            toEmail = memberEmail,
+            articleDayCol = articleDayCol,
+            articleTitle = article.articleTitle,
+            articleContent = Content.create(
+                memberEmail = memberEmail,
+                workbookId = workbookId,
+                articleId = article.id,
+                currentDate = date,
+                category = CategoryType.convertToDisplayName(article.category.toByte()),
+                articleDay = articleDayCol.toInt(),
+                articleTitle = article.articleTitle,
+                writerName = article.writerName,
+                writerLink = article.writerLink,
+                articleContent = article.articleContent
+            )
+        ).let {
+            runCatching { emailService.sendArticleEmail(it) }
+                .onSuccess {
+                    val lastDayArticleId = ReadWorkbookLastArticleIdInDto(
+                        workbookId
+                    ).let {
+                        workbookService.readWorkbookLastArticleId(it)
+                    }?.lastArticleId ?: throw NotFoundException("workbook.notfound.id")
+
+                    if (article.id == lastDayArticleId) {
+                        UpdateArticleProgressCommand(workbookId, memberId).let {
+                            subscriptionDao.updateArticleProgress(it)
+                        }
+                    } else {
+                        UpdateLastArticleProgressCommand(workbookId, memberId).let {
+                            subscriptionDao.updateLastArticleProgress(it)
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/handler/WorkbookSubscriptionClientAsyncHandler.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/handler/WorkbookSubscriptionClientAsyncHandler.kt
@@ -1,0 +1,36 @@
+package com.few.api.domain.subscription.handler
+
+import com.few.api.client.subscription.SubscriptionClient
+import com.few.api.client.subscription.dto.WorkbookSubscriptionArgs
+import com.few.api.config.ApiThreadPoolConfig.Companion.DISCORD_HOOK_EVENT_POOL
+import com.few.api.domain.subscription.service.SubscriptionWorkbookService
+import com.few.api.domain.subscription.service.dto.ReadWorkbookTitleInDto
+import com.few.api.exception.common.NotFoundException
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class WorkbookSubscriptionClientAsyncHandler(
+    private val subscriptionDao: SubscriptionDao,
+    private val subscriptionClient: SubscriptionClient,
+    private val workbookService: SubscriptionWorkbookService,
+) {
+
+    @Async(value = DISCORD_HOOK_EVENT_POOL)
+    fun sendSubscriptionEvent(workbookId: Long) {
+        val title = ReadWorkbookTitleInDto(workbookId).let { dto ->
+            workbookService.readWorkbookTitle(dto)?.workbookTitle
+                ?: throw NotFoundException("workbook.notfound.id")
+        }
+        subscriptionDao.countAllSubscriptionStatus().let { record ->
+            WorkbookSubscriptionArgs(
+                totalSubscriptions = record.totalSubscriptions,
+                activeSubscriptions = record.activeSubscriptions,
+                workbookTitle = title
+            ).let { args ->
+                subscriptionClient.announceWorkbookSubscription(args)
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionArticleService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionArticleService.kt
@@ -1,7 +1,10 @@
 package com.few.api.domain.subscription.service
 
+import com.few.api.domain.subscription.service.dto.ReadArticleContentInDto
+import com.few.api.domain.subscription.service.dto.ReadArticleContentOutDto
 import com.few.api.domain.subscription.service.dto.ReadArticleIdByWorkbookIdAndDayDto
 import com.few.api.repo.dao.article.ArticleDao
+import com.few.api.repo.dao.article.query.SelectArticleContentQuery
 import com.few.api.repo.dao.article.query.SelectArticleIdByWorkbookIdAndDayQuery
 import org.springframework.stereotype.Service
 
@@ -12,6 +15,21 @@ class SubscriptionArticleService(
     fun readArticleIdByWorkbookIdAndDay(dto: ReadArticleIdByWorkbookIdAndDayDto): Long? {
         SelectArticleIdByWorkbookIdAndDayQuery(dto.workbookId, dto.day).let { query ->
             return articleDao.selectArticleIdByWorkbookIdAndDay(query)
+        }
+    }
+
+    fun readArticleContent(dto: ReadArticleContentInDto): ReadArticleContentOutDto? {
+        return SelectArticleContentQuery(dto.articleId).let { query ->
+            articleDao.selectArticleContent(query)
+        }?.let {
+            ReadArticleContentOutDto(
+                it.id,
+                it.category,
+                it.articleTitle,
+                it.articleContent,
+                it.writerName,
+                it.writerLink
+            )
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionEmailService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionEmailService.kt
@@ -1,0 +1,31 @@
+package com.few.api.domain.subscription.service
+
+import com.few.api.domain.subscription.service.dto.SendArticleInDto
+import com.few.email.service.article.SendArticleEmailService
+import com.few.email.service.article.dto.SendArticleEmailArgs
+import org.springframework.stereotype.Service
+
+@Service
+class SubscriptionEmailService(
+    private val sendArticleEmailService: SendArticleEmailService,
+) {
+
+    companion object {
+        private const val ARTICLE_SUBJECT_TEMPLATE = "Day%d %s"
+        private const val ARTICLE_TEMPLATE = "article"
+    }
+
+    fun sendArticleEmail(dto: SendArticleInDto) {
+        SendArticleEmailArgs(
+            dto.toEmail,
+            ARTICLE_SUBJECT_TEMPLATE.format(
+                dto.articleDayCol,
+                dto.articleTitle
+            ),
+            ARTICLE_TEMPLATE,
+            dto.articleContent
+        ).let {
+            sendArticleEmailService.send(it)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionMemberService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionMemberService.kt
@@ -1,16 +1,15 @@
 package com.few.api.domain.subscription.service
 
-import com.few.api.domain.subscription.service.dto.InsertMemberInDto
-import com.few.api.domain.subscription.service.dto.MemberIdOutDto
-import com.few.api.domain.subscription.service.dto.ReadMemberIdInDto
+import com.few.api.domain.subscription.service.dto.*
 import com.few.api.exception.common.InsertException
 import com.few.api.repo.dao.member.MemberDao
 import com.few.api.repo.dao.member.command.InsertMemberCommand
 import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
+import com.few.api.repo.dao.member.query.SelectMemberEmailQuery
 import org.springframework.stereotype.Service
 
 @Service
-class MemberService(
+class SubscriptionMemberService(
     private val memberDao: MemberDao,
 ) {
 
@@ -21,5 +20,13 @@ class MemberService(
     fun insertMember(dto: InsertMemberInDto): MemberIdOutDto {
         return memberDao.insertMember(InsertMemberCommand(dto.email, dto.memberType))?.let { MemberIdOutDto(it) }
             ?: throw InsertException("member.insertfail.record")
+    }
+
+    fun readMemberEmail(dto: ReadMemberEmailInDto): ReadMemberEmailOutDto? {
+        return SelectMemberEmailQuery(dto.memberId).let { query ->
+            memberDao.selectMemberEmail(query)
+        }?.let {
+            ReadMemberEmailOutDto(it)
+        }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionWorkbookService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionWorkbookService.kt
@@ -1,19 +1,30 @@
 package com.few.api.domain.subscription.service
 
+import com.few.api.domain.subscription.service.dto.ReadWorkbookLastArticleIdInDto
+import com.few.api.domain.subscription.service.dto.ReadWorkbookLastArticleIdOutDto
 import com.few.api.domain.subscription.service.dto.ReadWorkbookTitleInDto
 import com.few.api.domain.subscription.service.dto.ReadWorkbookTitleOutDto
 import com.few.api.repo.dao.workbook.WorkbookDao
+import com.few.api.repo.dao.workbook.query.SelectWorkBookLastArticleIdQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import org.springframework.stereotype.Service
 
 @Service
-class WorkbookService(
+class SubscriptionWorkbookService(
     private val workbookDao: WorkbookDao,
 ) {
 
     fun readWorkbookTitle(dto: ReadWorkbookTitleInDto): ReadWorkbookTitleOutDto? {
         return SelectWorkBookRecordQuery(dto.workbookId).let { query ->
             workbookDao.selectWorkBook(query)?.title?.let { ReadWorkbookTitleOutDto(it) }
+        }
+    }
+
+    fun readWorkbookLastArticleId(dto: ReadWorkbookLastArticleIdInDto): ReadWorkbookLastArticleIdOutDto? {
+        return SelectWorkBookLastArticleIdQuery(dto.workbookId).let { query ->
+            workbookDao.selectWorkBookLastArticleId(query)
+        }?.let {
+            ReadWorkbookLastArticleIdOutDto(it)
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadArticleContentInDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadArticleContentInDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.subscription.service.dto
+
+data class ReadArticleContentInDto(
+    val articleId: Long,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadArticleContentOutDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadArticleContentOutDto.kt
@@ -1,0 +1,12 @@
+package com.few.api.domain.subscription.service.dto
+
+import java.net.URL
+
+data class ReadArticleContentOutDto(
+    val id: Long,
+    val category: String,
+    val articleTitle: String,
+    val articleContent: String,
+    val writerName: String,
+    val writerLink: URL,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadMemberEmailInDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadMemberEmailInDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.subscription.service.dto
+
+data class ReadMemberEmailInDto(
+    val memberId: Long,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadMemberEmailOutDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadMemberEmailOutDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.subscription.service.dto
+
+data class ReadMemberEmailOutDto(
+    val email: String,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadWorkbookLastArticleIdInDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadWorkbookLastArticleIdInDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.subscription.service.dto
+
+data class ReadWorkbookLastArticleIdInDto(
+    val workbookId: Long,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadWorkbookLastArticleIdOutDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/ReadWorkbookLastArticleIdOutDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.subscription.service.dto
+
+data class ReadWorkbookLastArticleIdOutDto(
+    val lastArticleId: Long,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/SendArticleInDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/SendArticleInDto.kt
@@ -1,0 +1,12 @@
+package com.few.api.domain.subscription.service.dto
+
+import com.few.email.service.article.dto.Content
+
+data class SendArticleInDto(
+    val memberId: Long,
+    val workbookId: Long,
+    val toEmail: String,
+    val articleDayCol: Byte,
+    val articleTitle: String,
+    val articleContent: Content,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCase.kt
@@ -20,8 +20,6 @@ class SubscribeWorkbookUseCase(
 
     @Transactional
     fun execute(useCaseIn: SubscribeWorkbookUseCaseIn) {
-        // TODO: request sending email
-
         val subTargetWorkbookId = useCaseIn.workbookId
         val memberId = useCaseIn.memberId
         val command = InsertWorkbookSubscriptionCommand(
@@ -54,6 +52,18 @@ class SubscribeWorkbookUseCase(
                 throw SubscribeIllegalArgumentException("subscribe.state.subscribed")
             }
         }
-        applicationEventPublisher.publishEvent(WorkbookSubscriptionEvent(workbookId = subTargetWorkbookId))
+
+        /**
+         * 구독 이벤트 발행
+         * @see com.few.api.domain.subscription.event.WorkbookSubscriptionEventListener
+         * @see com.few.api.domain.subscription.event.WorkbookSubscriptionAfterCompletionEventListener
+         */
+        applicationEventPublisher.publishEvent(
+            WorkbookSubscriptionEvent(
+                workbookId = subTargetWorkbookId,
+                memberId = memberId,
+                articleDayCol = subscriptionStatus?.day ?: 1
+            )
+        )
     }
 }

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
@@ -37,7 +37,7 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
 
             every { subscriptionDao.insertWorkbookSubscription(any()) } just Runs
 
-            val event = WorkbookSubscriptionEvent(workbookId)
+            val event = WorkbookSubscriptionEvent(workbookId, memberId, 1)
             every { applicationEventPublisher.publishEvent(event) } answers {
                 log.debug { "Mocking applicationEventPublisher.publishEvent(any()) was called" }
             }
@@ -66,7 +66,7 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
 
             every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
 
-            val event = WorkbookSubscriptionEvent(workbookId)
+            val event = WorkbookSubscriptionEvent(workbookId, memberId, day)
             every { applicationEventPublisher.publishEvent(event) } answers {
                 log.debug { "Mocking applicationEventPublisher.publishEvent(any()) was called" }
             }
@@ -93,7 +93,11 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
                 verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
                 verify(exactly = 0) { subscriptionDao.countWorkbookMappedArticles(any()) }
                 verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
-                verify(exactly = 0) { applicationEventPublisher.publishEvent(WorkbookSubscriptionEvent(workbookId)) }
+                verify(exactly = 0) {
+                    applicationEventPublisher.publishEvent(
+                        WorkbookSubscriptionEvent(workbookId, memberId, day)
+                    )
+                }
             }
         }
     }

--- a/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCaseTest.kt
@@ -82,6 +82,35 @@ class SubscribeWorkbookUseCaseTest : BehaviorSpec({
             }
         }
 
+        `when`("이미 구독한 히스토리가 있고 구독을 완료한 경우") {
+            val day = 3
+            every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns WorkbookSubscriptionStatus(
+                workbookId = workbookId,
+                isActiveSub = false,
+                day
+            )
+
+            val lastDay = day
+            every { subscriptionDao.countWorkbookMappedArticles(any()) } returns lastDay
+
+            every { subscriptionDao.reSubscribeWorkbookSubscription(any()) } just Runs
+
+            val event = WorkbookSubscriptionEvent(workbookId, memberId, day)
+            every { applicationEventPublisher.publishEvent(event) } answers {
+                log.debug { "Mocking applicationEventPublisher.publishEvent(any()) was called" }
+            }
+
+            then("예외가 발생한다") {
+                shouldThrow<Exception> { useCase.execute(useCaseIn) }
+
+                verify(exactly = 1) { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) }
+                verify(exactly = 0) { subscriptionDao.insertWorkbookSubscription(any()) }
+                verify(exactly = 1) { subscriptionDao.countWorkbookMappedArticles(any()) }
+                verify(exactly = 0) { subscriptionDao.reSubscribeWorkbookSubscription(any()) }
+                verify(exactly = 0) { applicationEventPublisher.publishEvent(event) }
+            }
+        }
+
         `when`("구독 중인 경우") {
             val day = 2
             every { subscriptionDao.selectTopWorkbookSubscriptionStatus(any()) } returns WorkbookSubscriptionStatus(workbookId = workbookId, isActiveSub = true, day)

--- a/email/src/main/kotlin/com/few/email/service/article/dto/SendArticleEmailArgs.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/dto/SendArticleEmailArgs.kt
@@ -23,4 +23,30 @@ data class Content(
     val articleContent: String,
     val problemLink: URL,
     val unsubscribeLink: URL,
-)
+) {
+    companion object {
+        fun create(
+            memberEmail: String,
+            workbookId: Long,
+            articleId: Long,
+            currentDate: LocalDate,
+            category: String,
+            articleDay: Int,
+            articleTitle: String,
+            writerName: String,
+            writerLink: URL,
+            articleContent: String,
+        ) = Content(
+            articleLink = URL("https://www.fewletter.com/article/$articleId"),
+            currentDate,
+            category,
+            articleDay,
+            articleTitle,
+            writerName,
+            writerLink,
+            articleContent,
+            problemLink = URL("https://www.fewletter.com/problem?articleId=$articleId"),
+            unsubscribeLink = URL("https://www.fewletter.com/unsubscribe?user=$memberEmail&workbookId=$workbookId&articleId=$articleId")
+        )
+    }
+}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #360 

💁‍♂️ PR 내용
----
- 구독과 동시에 아티클 전송할 수 있도록 수정

🙏 작업
----
- 구독 이벤트 내용 수정
    -  as-is: 워크북 ID, to-be: 워크북 ID 멤버 ID 날짜
- 이벤트 리스너 구현 통일
- 트렌젝션이 완료된 이후 동작하는 리스너 구현 : 이메일 전송 성공/실패 여부를 UC 트랜잭션과 분리하기 위해서

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
