### PR TITLE
[Refactor/#372] 범위지정 함수 구현 통일

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
@@ -70,12 +70,12 @@ class SubscriptionDao(
             .orderBy(SUBSCRIPTION.CREATED_AT.desc())
             .limit(1)
 
-    fun selectAllInActiveWorkbookSubscriptionStatus(query: SelectAllMemberWorkbookInActiveSubscription): List<MemberWorkbookSubscriptionStatusRecord> {
+    fun selectAllInActiveWorkbookSubscriptionStatus(query: SelectAllMemberWorkbookInActiveSubscriptionQuery): List<MemberWorkbookSubscriptionStatusRecord> {
         return selectAllWorkbookInActiveSubscriptionStatusQuery(query)
             .fetchInto(MemberWorkbookSubscriptionStatusRecord::class.java)
     }
 
-    fun selectAllWorkbookInActiveSubscriptionStatusQuery(query: SelectAllMemberWorkbookInActiveSubscription) =
+    fun selectAllWorkbookInActiveSubscriptionStatusQuery(query: SelectAllMemberWorkbookInActiveSubscriptionQuery) =
         dslContext.select(
             SUBSCRIPTION.TARGET_WORKBOOK_ID.`as`(MemberWorkbookSubscriptionStatusRecord::workbookId.name),
             SUBSCRIPTION.DELETED_AT.isNull.`as`(MemberWorkbookSubscriptionStatusRecord::isActiveSub.name),
@@ -91,12 +91,12 @@ class SubscriptionDao(
             .groupBy(SUBSCRIPTION.TARGET_WORKBOOK_ID, SUBSCRIPTION.DELETED_AT)
             .query
 
-    fun selectAllActiveWorkbookSubscriptionStatus(query: SelectAllMemberWorkbookActiveSubscription): List<MemberWorkbookSubscriptionStatusRecord> {
+    fun selectAllActiveWorkbookSubscriptionStatus(query: SelectAllMemberWorkbookActiveSubscriptionQuery): List<MemberWorkbookSubscriptionStatusRecord> {
         return selectAllWorkbookActiveSubscriptionStatusQuery(query)
             .fetchInto(MemberWorkbookSubscriptionStatusRecord::class.java)
     }
 
-    fun selectAllWorkbookActiveSubscriptionStatusQuery(query: SelectAllMemberWorkbookActiveSubscription) =
+    fun selectAllWorkbookActiveSubscriptionStatusQuery(query: SelectAllMemberWorkbookActiveSubscriptionQuery) =
         dslContext.select(
             SUBSCRIPTION.TARGET_WORKBOOK_ID.`as`(MemberWorkbookSubscriptionStatusRecord::workbookId.name),
             SUBSCRIPTION.DELETED_AT.isNull.`as`(MemberWorkbookSubscriptionStatusRecord::isActiveSub.name),
@@ -148,7 +148,7 @@ class SubscriptionDao(
      * key: workbookId
      * value: workbook 구독 전체 기록 수
      */
-    fun countAllWorkbookSubscription(query: CountAllWorkbooksSubscription): Map<Long, Int> {
+    fun countAllWorkbookSubscription(query: CountAllWorkbooksSubscriptionQuery): Map<Long, Int> {
         return countAllWorkbookSubscriptionQuery()
             .fetch()
             .intoMap(SUBSCRIPTION.TARGET_WORKBOOK_ID, DSL.count(SUBSCRIPTION.TARGET_WORKBOOK_ID))

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountAllWorkbooksSubscriptionQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/CountAllWorkbooksSubscriptionQuery.kt
@@ -1,5 +1,5 @@
 package com.few.api.repo.dao.subscription.query
 
-data class CountAllWorkbooksSubscription(
+data class CountAllWorkbooksSubscriptionQuery(
     val workbookIds: List<Long>,
 )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllMemberWorkbookActiveSubscriptionQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllMemberWorkbookActiveSubscriptionQuery.kt
@@ -3,6 +3,6 @@ package com.few.api.repo.dao.subscription.query
 /**
  * 멤버의 구독 중인 워크북 목록을 조회합니다.
  */
-data class SelectAllMemberWorkbookActiveSubscription(
+data class SelectAllMemberWorkbookActiveSubscriptionQuery(
     val memberId: Long,
 )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllMemberWorkbookInActiveSubscriptionQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectAllMemberWorkbookInActiveSubscriptionQuery.kt
@@ -3,7 +3,7 @@ package com.few.api.repo.dao.subscription.query
 /**
  * 멤버의 구독 완료 워크북 목록을 조회합니다.
  */
-data class SelectAllMemberWorkbookInActiveSubscription(
+data class SelectAllMemberWorkbookInActiveSubscriptionQuery(
     val memberId: Long,
     val unsubOpinion: String = "receive.all",
 )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/WorkbookDao.kt
@@ -4,7 +4,7 @@ import com.few.api.repo.config.LocalCacheConfig
 import com.few.api.repo.config.LocalCacheConfig.Companion.LOCAL_CM
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
 import com.few.api.repo.dao.workbook.command.MapWorkBookToArticleCommand
-import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
+import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCountQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookLastArticleIdQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import com.few.api.repo.dao.workbook.record.SelectWorkBookRecord
@@ -71,12 +71,12 @@ class WorkbookDao(
      * category에 따라서 조회된 구독자 수가 포함된 Workbook 목록을 반환한다.
      * 정렬 순서는 구독자 수가 많은 순서로, 구독자 수가 같다면 생성일자가 최신인 순서로 반환한다.
      */
-    fun browseWorkBookWithSubscriptionCount(query: BrowseWorkBookQueryWithSubscriptionCount): List<SelectWorkBookRecordWithSubscriptionCount> {
+    fun browseWorkBookWithSubscriptionCount(query: BrowseWorkBookQueryWithSubscriptionCountQuery): List<SelectWorkBookRecordWithSubscriptionCount> {
         return browseWorkBookQuery(query)
             .fetchInto(SelectWorkBookRecordWithSubscriptionCount::class.java)
     }
 
-    fun browseWorkBookQuery(query: BrowseWorkBookQueryWithSubscriptionCount) =
+    fun browseWorkBookQuery(query: BrowseWorkBookQueryWithSubscriptionCountQuery) =
         dslContext.select(
             Workbook.WORKBOOK.ID.`as`(SelectWorkBookRecordWithSubscriptionCount::id.name),
             Workbook.WORKBOOK.TITLE.`as`(SelectWorkBookRecordWithSubscriptionCount::title.name),
@@ -124,7 +124,7 @@ class WorkbookDao(
     /**
      * category에 따라서 조건을 생성한다.
      */
-    private fun browseWorkBookCategoryCondition(query: BrowseWorkBookQueryWithSubscriptionCount): Condition {
+    private fun browseWorkBookCategoryCondition(query: BrowseWorkBookQueryWithSubscriptionCountQuery): Condition {
         return when (query.category) {
             (-1).toByte() -> DSL.noCondition()
             else -> Workbook.WORKBOOK.CATEGORY_CD.eq(query.category)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/query/BrowseWorkBookQueryWithSubscriptionCountQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/workbook/query/BrowseWorkBookQueryWithSubscriptionCountQuery.kt
@@ -1,6 +1,6 @@
 package com.few.api.repo.dao.workbook.query
 
-data class BrowseWorkBookQueryWithSubscriptionCount(
+data class BrowseWorkBookQueryWithSubscriptionCountQuery(
     /**
      * @see com.few.api.web.support.WorkBookCategory
      */

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
@@ -3,9 +3,9 @@ package com.few.api.repo.explain.subscription
 import com.few.api.repo.dao.subscription.SubscriptionDao
 import com.few.api.repo.dao.subscription.command.*
 import com.few.api.repo.dao.subscription.query.CountWorkbookMappedArticlesQuery
-import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookActiveSubscription
+import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookActiveSubscriptionQuery
 import com.few.api.repo.dao.subscription.query.SelectAllWorkbookSubscriptionStatusNotConsiderDeletedAtQuery
-import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookInActiveSubscription
+import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookInActiveSubscriptionQuery
 import com.few.api.repo.explain.ExplainGenerator
 import com.few.api.repo.explain.InsertUpdateExplainGenerator
 import com.few.api.repo.explain.ResultGenerator
@@ -63,7 +63,7 @@ class SubscriptionDaoExplainGenerateTest : JooqTestSpec() {
 
     @Test
     fun selectAllWorkbookInActiveSubscriptionStatusQueryExplain() {
-        val query = SelectAllMemberWorkbookInActiveSubscription(
+        val query = SelectAllMemberWorkbookInActiveSubscriptionQuery(
             memberId = 1L,
             unsubOpinion = "receive.all"
         ).let {
@@ -77,7 +77,7 @@ class SubscriptionDaoExplainGenerateTest : JooqTestSpec() {
 
     @Test
     fun selectAllWorkbookActiveSubscriptionStatusQueryExplain() {
-        val query = SelectAllMemberWorkbookActiveSubscription(
+        val query = SelectAllMemberWorkbookActiveSubscriptionQuery(
             memberId = 1L
         ).let {
             subscriptionDao.selectAllWorkbookActiveSubscriptionStatusQuery(it)

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/workbook/WorkbookDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/workbook/WorkbookDaoExplainGenerateTest.kt
@@ -3,7 +3,7 @@ package com.few.api.repo.explain.workbook
 import com.few.api.repo.dao.workbook.WorkbookDao
 import com.few.api.repo.dao.workbook.command.InsertWorkBookCommand
 import com.few.api.repo.dao.workbook.command.MapWorkBookToArticleCommand
-import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
+import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCountQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookLastArticleIdQuery
 import com.few.api.repo.dao.workbook.query.SelectWorkBookRecordQuery
 import com.few.api.repo.explain.ExplainGenerator
@@ -73,7 +73,7 @@ class WorkbookDaoExplainGenerateTest : JooqTestSpec() {
 
     @Test
     fun browseWorkBookQueryNoConditionQueryExplain() {
-        val query = BrowseWorkBookQueryWithSubscriptionCount(-1).let {
+        val query = BrowseWorkBookQueryWithSubscriptionCountQuery(-1).let {
             workbookDao.browseWorkBookQuery(it)
         }
 
@@ -84,7 +84,7 @@ class WorkbookDaoExplainGenerateTest : JooqTestSpec() {
 
     @Test
     fun browseWorkBookQueryCategoryConditionExplain() {
-        val query = BrowseWorkBookQueryWithSubscriptionCount(CategoryType.fromCode(0)!!.code).let {
+        val query = BrowseWorkBookQueryWithSubscriptionCountQuery(CategoryType.fromCode(0)!!.code).let {
             workbookDao.browseWorkBookQuery(it)
         }
 

--- a/api/src/main/kotlin/com/few/api/client/repo/RepoClient.kt
+++ b/api/src/main/kotlin/com/few/api/client/repo/RepoClient.kt
@@ -18,15 +18,15 @@ class RepoClient(
     private val log = KotlinLogging.logger {}
 
     fun announceRepoAlter(args: RepoAlterArgs) {
-        val embedsList = ArrayList<Embed>()
-        args.let {
-            embedsList.add(
-                Embed(
-                    title = "Exception",
-                    description = "Slow Query Detected"
-                )
+        val embedsList = mutableListOf(
+            Embed(
+                title = "Exception",
+                description = "Slow Query Detected"
             )
-            it.requestURL.let { requestURL ->
+        )
+
+        args.let { arg ->
+            arg.requestURL.let { requestURL ->
                 embedsList.add(
                     Embed(
                         title = "Request URL",
@@ -34,7 +34,8 @@ class RepoClient(
                     )
                 )
             }
-            it.query?.let { query ->
+
+            arg.query?.let { query ->
                 embedsList.add(
                     Embed(
                         title = "Slow Query Detected",
@@ -43,20 +44,19 @@ class RepoClient(
                 )
             }
         }
-        args.let {
-            DiscordBodyProperty(
-                content = "😭 DB 이상 발생",
-                embeds = embedsList
-            )
-        }.let { body ->
-            restTemplate.exchange(
-                discordWebhook,
-                HttpMethod.POST,
-                HttpEntity(body),
-                String::class.java
-            ).let { res ->
-                log.info { "Discord webhook response: ${res.statusCode}" }
-            }
+
+        restTemplate.exchange(
+            discordWebhook,
+            HttpMethod.POST,
+            HttpEntity(
+                DiscordBodyProperty(
+                    content = "😭 DB 이상 발생",
+                    embeds = embedsList
+                )
+            ),
+            String::class.java
+        ).let { res ->
+            log.info { "Discord webhook response: ${res.statusCode}" }
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/client/repo/event/SlowQueryEventListener.kt
+++ b/api/src/main/kotlin/com/few/api/client/repo/event/SlowQueryEventListener.kt
@@ -17,11 +17,10 @@ class SlowQueryEventListener(
     @Async(value = DISCORD_HOOK_EVENT_POOL)
     @EventListener
     fun handleSlowQueryEvent(event: SlowQueryEvent) {
-        RepoAlterArgs(
+        val args = RepoAlterArgs(
             requestURL = MDC.get("Request-URL") ?: "",
             query = event.slowQuery
-        ).let {
-            repoClient.announceRepoAlter(it)
-        }
+        )
+        repoClient.announceRepoAlter(args)
     }
 }

--- a/api/src/main/kotlin/com/few/api/client/subscription/SubscriptionClient.kt
+++ b/api/src/main/kotlin/com/few/api/client/subscription/SubscriptionClient.kt
@@ -18,33 +18,33 @@ class SubscriptionClient(
     private val log = KotlinLogging.logger {}
 
     fun announceWorkbookSubscription(args: WorkbookSubscriptionArgs) {
-        args.let {
+        val body = args.let { arg ->
             DiscordBodyProperty(
                 content = "🎉 신규 구독 알림 ",
                 embeds = listOf(
                     Embed(
                         title = "Total Subscriptions",
-                        description = it.totalSubscriptions.toString()
+                        description = arg.totalSubscriptions.toString()
                     ),
                     Embed(
                         title = "Active Subscriptions",
-                        description = it.activeSubscriptions.toString()
+                        description = arg.activeSubscriptions.toString()
                     ),
                     Embed(
                         title = "Workbook Title",
-                        description = it.workbookTitle
+                        description = arg.workbookTitle
                     )
                 )
             )
-        }.let { body ->
-            restTemplate.exchange(
-                discordWebhook,
-                HttpMethod.POST,
-                HttpEntity(body),
-                String::class.java
-            ).let { res ->
-                log.info { "Discord webhook response: ${res.statusCode}" }
-            }
+        }
+
+        restTemplate.exchange(
+            discordWebhook,
+            HttpMethod.POST,
+            HttpEntity(body),
+            String::class.java
+        ).let { res ->
+            log.info { "Discord webhook response: ${res.statusCode}" }
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/config/crypto/IdEncryption.kt
+++ b/api/src/main/kotlin/com/few/api/config/crypto/IdEncryption.kt
@@ -16,19 +16,15 @@ class IdEncryption(
     @Value("\${security.encryption.iv}") private val iv: String,
 ) : Encryption<String, String> {
 
-    private lateinit var key: SecretKeySpec
-    private lateinit var encodeCipher: Cipher
-    private lateinit var decodeCipher: Cipher
-
-    init {
-        KeyGenerator.getInstance(algorithm).apply {
-            init(keySize)
-            key = SecretKeySpec(secretKey.toByteArray(), algorithm)
-        }
-        encodeCipher = Cipher.getInstance(transformation)
-        decodeCipher = Cipher.getInstance(transformation)
-        encodeCipher.init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(iv.toByteArray()))
-        decodeCipher.init(Cipher.DECRYPT_MODE, key, IvParameterSpec(iv.toByteArray()))
+    private var key: SecretKeySpec = KeyGenerator.getInstance(algorithm).run {
+        init(keySize)
+        SecretKeySpec(secretKey.toByteArray(), algorithm)
+    }
+    private var encodeCipher: Cipher = Cipher.getInstance(transformation).apply {
+        init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(this@IdEncryption.iv.toByteArray()))
+    }
+    private var decodeCipher: Cipher = Cipher.getInstance(transformation).apply {
+        init(Cipher.DECRYPT_MODE, key, IvParameterSpec(this@IdEncryption.iv.toByteArray()))
     }
 
     override fun encrypt(plainText: String): String {

--- a/api/src/main/kotlin/com/few/api/config/crypto/IdEncryption.kt
+++ b/api/src/main/kotlin/com/few/api/config/crypto/IdEncryption.kt
@@ -16,9 +16,10 @@ class IdEncryption(
     @Value("\${security.encryption.iv}") private val iv: String,
 ) : Encryption<String, String> {
 
-    private var key: SecretKeySpec = KeyGenerator.getInstance(algorithm).run {
+    private var key: SecretKeySpec = KeyGenerator.getInstance(algorithm).apply {
         init(keySize)
-        SecretKeySpec(secretKey.toByteArray(), algorithm)
+    }.run {
+        SecretKeySpec(secretKey.toByteArray(), this@IdEncryption.algorithm)
     }
     private var encodeCipher: Cipher = Cipher.getInstance(transformation).apply {
         init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(this@IdEncryption.iv.toByteArray()))

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/service/ArticleMainCardService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/service/ArticleMainCardService.kt
@@ -42,12 +42,12 @@ class ArticleMainCardService(
 
         val articleMainCardRecord: ArticleMainCardRecord =
             articleMainCardDao.selectArticleMainCardsRecord(setOf(inDto.articleId))
-                .ifEmpty { throw NotFoundException("articlemaincard.notfound.id") }
-                .first()
+                .firstOrNull() ?: throw NotFoundException("article.notfound.id")
 
         val workbookCommands =
-            articleMainCardRecord.workbooks.map { WorkbookCommand(it.id!!, it.title!!) }.toMutableList()
-        workbookCommands.add(toBeAddedWorkbook)
+            articleMainCardRecord.workbooks.map { WorkbookCommand(it.id!!, it.title!!) }
+                .toMutableList()
+                .apply { add(toBeAddedWorkbook) }
 
         articleMainCardDao.updateArticleMainCardSetWorkbook(
             UpdateArticleMainCardWorkbookCommand(

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/service/GetUrlService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/service/GetUrlService.kt
@@ -21,13 +21,9 @@ class GetLocalUrlService(
     private val services: Map<String, GetPreSignedObjectUrlService>,
 ) : GetUrlService {
     override fun execute(query: GetUrlInDto): GetUrlOutDto {
-        val service = services.keys.stream().filter { key ->
-            key.lowercase(Locale.getDefault())
-                .contains(query.getPreSignedUrlServiceKey())
-        }.findAny().let {
-            if (it.isEmpty) throw IllegalArgumentException("Cannot find service for ${query.getPreSignedUrlServiceKey()}")
-            services[it.get()]!!
-        }
+        val service = services.keys.firstOrNull { key ->
+            key.lowercase(Locale.getDefault()).contains(query.getPreSignedUrlServiceKey())
+        }?.let { services[it] } ?: throw IllegalArgumentException("Cannot find service for ${query.getPreSignedUrlServiceKey()}")
 
         return service.execute(query.`object`)?.let {
             GetUrlOutDto(URL(it))

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/AddWorkbookUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/AddWorkbookUseCase.kt
@@ -14,14 +14,15 @@ class AddWorkbookUseCase(
 ) {
     @Transactional
     fun execute(useCaseIn: AddWorkbookUseCaseIn): AddWorkbookUseCaseOut {
-        val workbookId = InsertWorkBookCommand(
-            title = useCaseIn.title,
-            mainImageUrl = useCaseIn.mainImageUrl,
-            category = useCaseIn.category,
-            description = useCaseIn.description
-        ).let {
-            workbookDao.insertWorkBook(it)
-        } ?: throw InsertException("workbook.insertfail.record")
+        val workbookId =
+            workbookDao.insertWorkBook(
+                InsertWorkBookCommand(
+                    title = useCaseIn.title,
+                    mainImageUrl = useCaseIn.mainImageUrl,
+                    category = useCaseIn.category,
+                    description = useCaseIn.description
+                )
+            ) ?: throw InsertException("workbook.insertfail.record")
 
         return AddWorkbookUseCaseOut(workbookId)
     }

--- a/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/MapArticleUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/admin/document/usecase/MapArticleUseCase.kt
@@ -15,9 +15,14 @@ class MapArticleUseCase(
 ) {
     @Transactional
     fun execute(useCaseIn: MapArticleUseCaseIn) {
-        MapWorkBookToArticleCommand(useCaseIn.workbookId, useCaseIn.articleId, useCaseIn.dayCol).let { command ->
-            workbookDao.mapWorkBookToArticle(command)
-        }
+        workbookDao.mapWorkBookToArticle(
+            MapWorkBookToArticleCommand(
+                useCaseIn.workbookId,
+                useCaseIn.articleId,
+                useCaseIn.dayCol
+            )
+
+        )
 
         articleMainCardService.appendWorkbook(
             AppendWorkbookToArticleMainCardInDto(useCaseIn.articleId, useCaseIn.workbookId)

--- a/api/src/main/kotlin/com/few/api/domain/article/service/BrowseArticleProblemsService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/BrowseArticleProblemsService.kt
@@ -7,15 +7,15 @@ import com.few.api.repo.dao.problem.ProblemDao
 import com.few.api.repo.dao.problem.query.SelectProblemsByArticleIdQuery
 import org.springframework.stereotype.Service
 
+@Suppress("NAME_SHADOWING")
 @Service
 class BrowseArticleProblemsService(
     private val problemDao: ProblemDao,
 ) {
 
     fun execute(query: BrowseArticleProblemIdsInDto): BrowseArticleProblemsOutDto {
-        SelectProblemsByArticleIdQuery(query.articleId).let { query: SelectProblemsByArticleIdQuery ->
-            return problemDao.selectProblemsByArticleId(query)?.let { BrowseArticleProblemsOutDto(it.problemIds) }
-                ?: throw NotFoundException("problem.notfound.articleId")
-        }
+        return problemDao.selectProblemsByArticleId(SelectProblemsByArticleIdQuery(query.articleId))
+            ?.let { BrowseArticleProblemsOutDto(it.problemIds) }
+            ?: throw NotFoundException("problem.notfound.articleId")
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/article/service/ReadArticleWriterRecordService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/ReadArticleWriterRecordService.kt
@@ -6,15 +6,15 @@ import com.few.api.repo.dao.member.MemberDao
 import com.few.api.repo.dao.member.query.SelectWriterQuery
 import org.springframework.stereotype.Service
 
+@Suppress("NAME_SHADOWING")
 @Service
 class ReadArticleWriterRecordService(
     private val memberDao: MemberDao,
 ) {
 
     fun execute(query: ReadWriterRecordInDto): ReadWriterOutDto? {
-        SelectWriterQuery(query.writerId).let { query: SelectWriterQuery ->
-            val record = memberDao.selectWriter(query)
-            return record?.let {
+        return memberDao.selectWriter(SelectWriterQuery(query.writerId))
+            ?.let {
                 ReadWriterOutDto(
                     writerId = it.writerId,
                     name = it.name,
@@ -22,6 +22,5 @@ class ReadArticleWriterRecordService(
                     imageUrl = it.imageUrl
                 )
             }
-        }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/BrowseArticlesUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/BrowseArticlesUseCase.kt
@@ -60,7 +60,7 @@ class BrowseArticlesUseCase(
         /**
          * ARTICLE_MAIN_CARD 테이블에서 이번 스크롤에서 보여줄 10개 아티클 조회 (TODO: 캐싱 적용)
          */
-        var articleMainCardRecords: Set<ArticleMainCardRecord> =
+        val articleMainCardRecords: Set<ArticleMainCardRecord> =
             articleMainCardDao.selectArticleMainCardsRecord(articleViewsRecords.map { it.articleId }.toSet())
 
         /**

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticleUseCase.kt
@@ -28,18 +28,16 @@ class ReadArticleUseCase(
 
     @Transactional(readOnly = true)
     fun execute(useCaseIn: ReadArticleUseCaseIn): ReadArticleUseCaseOut {
-        val articleRecord = SelectArticleRecordQuery(useCaseIn.articleId).let { query: SelectArticleRecordQuery ->
-            articleDao.selectArticleRecord(query)
-        } ?: throw NotFoundException("article.notfound.id")
+        val articleRecord =
+            articleDao.selectArticleRecord(SelectArticleRecordQuery(useCaseIn.articleId))
+                ?: throw NotFoundException("article.notfound.id")
 
-        val writerRecord = ReadWriterRecordInDto(articleRecord.writerId).let { query: ReadWriterRecordInDto ->
-            readArticleWriterRecordService.execute(query) ?: throw NotFoundException("writer.notfound.id")
-        }
+        val writerRecord =
+            readArticleWriterRecordService.execute(ReadWriterRecordInDto(articleRecord.writerId))
+                ?: throw NotFoundException("writer.notfound.id")
 
         val problemIds =
-            BrowseArticleProblemIdsInDto(articleRecord.articleId).let { query: BrowseArticleProblemIdsInDto ->
-                browseArticleProblemsService.execute(query)
-            }
+            browseArticleProblemsService.execute(BrowseArticleProblemIdsInDto(articleRecord.articleId))
 
         val views = articleViewCountHandler.browseArticleViewCount(useCaseIn.articleId)
         applicationEventPublisher.publishEvent(

--- a/api/src/main/kotlin/com/few/api/domain/log/AddApiLogUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/log/AddApiLogUseCase.kt
@@ -12,8 +12,6 @@ class AddApiLogUseCase(
 ) {
     @Transactional
     fun execute(useCaseIn: AddApiLogUseCaseIn) {
-        InsertLogCommand(useCaseIn.history).let {
-            logIfoDao.insertLogIfo(it)
-        }
+        logIfoDao.insertLogIfo(InsertLogCommand(useCaseIn.history))
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/member/usecase/DeleteMemberUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/member/usecase/DeleteMemberUseCase.kt
@@ -14,11 +14,11 @@ class DeleteMemberUseCase(
 ) {
     @Transactional
     fun execute(useCaseIn: DeleteMemberUseCaseIn): DeleteMemberUseCaseOut {
-        DeleteMemberCommand(
-            memberId = useCaseIn.memberId
-        ).let { command ->
-            memberDao.deleteMember(command)
-        }
+        memberDao.deleteMember(
+            DeleteMemberCommand(
+                memberId = useCaseIn.memberId
+            )
+        )
 
         return DeleteMemberUseCaseOut(true)
     }

--- a/api/src/main/kotlin/com/few/api/domain/member/usecase/TokenUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/member/usecase/TokenUseCase.kt
@@ -62,12 +62,12 @@ class TokenUseCase(
 
         if (memberEmailAndTypeRecord.memberType == MemberType.PREAUTH) {
             isLogin = false
-            UpdateMemberTypeCommand(
-                id = memberId,
-                memberType = MemberType.NORMAL
-            ).let { command ->
-                memberDao.updateMemberType(command)
-            }
+            memberDao.updateMemberType(
+                UpdateMemberTypeCommand(
+                    id = memberId,
+                    memberType = MemberType.NORMAL
+                )
+            )
         }
 
         /** id가 요청에 포함되어 있으면 id를 통해 새로운 토큰을 발급 */

--- a/api/src/main/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/problem/usecase/BrowseProblemsUseCase.kt
@@ -13,10 +13,9 @@ class BrowseProblemsUseCase(
 ) {
 
     fun execute(useCaseIn: BrowseProblemsUseCaseIn): BrowseProblemsUseCaseOut {
-        SelectProblemsByArticleIdQuery(useCaseIn.articleId).let { query: SelectProblemsByArticleIdQuery ->
-            problemDao.selectProblemsByArticleId(query) ?: throw NotFoundException("problem.notfound.articleId")
-        }.let {
-            return BrowseProblemsUseCaseOut(it.problemIds)
-        }
+        problemDao.selectProblemsByArticleId(SelectProblemsByArticleIdQuery(useCaseIn.articleId))
+            ?.let {
+                return BrowseProblemsUseCaseOut(it.problemIds)
+            } ?: throw NotFoundException("problem.notfound.articleId")
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/handler/WorkbookSubscriptionClientAsyncHandler.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/handler/WorkbookSubscriptionClientAsyncHandler.kt
@@ -19,18 +19,18 @@ class WorkbookSubscriptionClientAsyncHandler(
 
     @Async(value = DISCORD_HOOK_EVENT_POOL)
     fun sendSubscriptionEvent(workbookId: Long) {
-        val title = ReadWorkbookTitleInDto(workbookId).let { dto ->
-            workbookService.readWorkbookTitle(dto)?.workbookTitle
+        val title =
+            workbookService.readWorkbookTitle(ReadWorkbookTitleInDto(workbookId))?.workbookTitle
                 ?: throw NotFoundException("workbook.notfound.id")
-        }
-        subscriptionDao.countAllSubscriptionStatus().let { record ->
-            WorkbookSubscriptionArgs(
-                totalSubscriptions = record.totalSubscriptions,
-                activeSubscriptions = record.activeSubscriptions,
-                workbookTitle = title
-            ).let { args ->
-                subscriptionClient.announceWorkbookSubscription(args)
-            }
+
+        subscriptionDao.countAllSubscriptionStatus().also { record ->
+            subscriptionClient.announceWorkbookSubscription(
+                WorkbookSubscriptionArgs(
+                    totalSubscriptions = record.totalSubscriptions,
+                    activeSubscriptions = record.activeSubscriptions,
+                    workbookTitle = title
+                )
+            )
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionArticleService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionArticleService.kt
@@ -13,15 +13,16 @@ class SubscriptionArticleService(
     private val articleDao: ArticleDao,
 ) {
     fun readArticleIdByWorkbookIdAndDay(dto: ReadArticleIdByWorkbookIdAndDayDto): Long? {
-        SelectArticleIdByWorkbookIdAndDayQuery(dto.workbookId, dto.day).let { query ->
-            return articleDao.selectArticleIdByWorkbookIdAndDay(query)
-        }
+        return articleDao.selectArticleIdByWorkbookIdAndDay(
+            SelectArticleIdByWorkbookIdAndDayQuery(
+                dto.workbookId,
+                dto.day
+            )
+        )
     }
 
     fun readArticleContent(dto: ReadArticleContentInDto): ReadArticleContentOutDto? {
-        return SelectArticleContentQuery(dto.articleId).let { query ->
-            articleDao.selectArticleContent(query)
-        }?.let {
+        return articleDao.selectArticleContent(SelectArticleContentQuery(dto.articleId))?.let {
             ReadArticleContentOutDto(
                 it.id,
                 it.category,

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionEmailService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionEmailService.kt
@@ -16,16 +16,16 @@ class SubscriptionEmailService(
     }
 
     fun sendArticleEmail(dto: SendArticleInDto) {
-        SendArticleEmailArgs(
-            dto.toEmail,
-            ARTICLE_SUBJECT_TEMPLATE.format(
-                dto.articleDayCol,
-                dto.articleTitle
-            ),
-            ARTICLE_TEMPLATE,
-            dto.articleContent
-        ).let {
-            sendArticleEmailService.send(it)
-        }
+        sendArticleEmailService.send(
+            SendArticleEmailArgs(
+                dto.toEmail,
+                ARTICLE_SUBJECT_TEMPLATE.format(
+                    dto.articleDayCol,
+                    dto.articleTitle
+                ),
+                ARTICLE_TEMPLATE,
+                dto.articleContent
+            )
+        )
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionMemberService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionMemberService.kt
@@ -23,9 +23,7 @@ class SubscriptionMemberService(
     }
 
     fun readMemberEmail(dto: ReadMemberEmailInDto): ReadMemberEmailOutDto? {
-        return SelectMemberEmailQuery(dto.memberId).let { query ->
-            memberDao.selectMemberEmail(query)
-        }?.let {
+        return memberDao.selectMemberEmail(SelectMemberEmailQuery(dto.memberId))?.let {
             ReadMemberEmailOutDto(it)
         }
     }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionWorkbookService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionWorkbookService.kt
@@ -15,16 +15,19 @@ class SubscriptionWorkbookService(
 ) {
 
     fun readWorkbookTitle(dto: ReadWorkbookTitleInDto): ReadWorkbookTitleOutDto? {
-        return SelectWorkBookRecordQuery(dto.workbookId).let { query ->
-            workbookDao.selectWorkBook(query)?.title?.let { ReadWorkbookTitleOutDto(it) }
-        }
+        return workbookDao.selectWorkBook(SelectWorkBookRecordQuery(dto.workbookId))
+            ?.title
+            ?.let {
+                ReadWorkbookTitleOutDto(
+                    it
+                )
+            }
     }
 
     fun readWorkbookLastArticleId(dto: ReadWorkbookLastArticleIdInDto): ReadWorkbookLastArticleIdOutDto? {
-        return SelectWorkBookLastArticleIdQuery(dto.workbookId).let { query ->
-            workbookDao.selectWorkBookLastArticleId(query)
-        }?.let {
-            ReadWorkbookLastArticleIdOutDto(it)
-        }
+        return workbookDao.selectWorkBookLastArticleId(SelectWorkBookLastArticleIdQuery(dto.workbookId))
+            ?.let {
+                ReadWorkbookLastArticleIdOutDto(it)
+            }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/workbook/article/usecase/ReadWorkBookArticleUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/article/usecase/ReadWorkBookArticleUseCase.kt
@@ -27,22 +27,19 @@ class ReadWorkBookArticleUseCase(
 ) {
     @Transactional(readOnly = true)
     fun execute(useCaseIn: ReadWorkBookArticleUseCaseIn): ReadWorkBookArticleOut {
-        val articleRecord = SelectWorkBookArticleRecordQuery(
-            useCaseIn.workbookId,
-            useCaseIn.articleId
-        ).let { query: SelectWorkBookArticleRecordQuery ->
-            articleDao.selectWorkBookArticleRecord(query)
-        } ?: throw NotFoundException("article.notfound.articleidworkbookid")
+        val articleRecord = articleDao.selectWorkBookArticleRecord(
+            SelectWorkBookArticleRecordQuery(
+                useCaseIn.workbookId,
+                useCaseIn.articleId
+            )
+        ) ?: throw NotFoundException("article.notfound.articleidworkbookid")
 
         val writerRecord =
-            ReadWriterRecordInDto(articleRecord.writerId).let { query: ReadWriterRecordInDto ->
-                readArticleWriterRecordService.execute(query) ?: throw NotFoundException("writer.notfound.id")
-            }
+            readArticleWriterRecordService.execute(ReadWriterRecordInDto(articleRecord.writerId))
+                ?: throw NotFoundException("writer.notfound.id")
 
         val problemIds =
-            BrowseArticleProblemIdsInDto(articleRecord.articleId).let { query: BrowseArticleProblemIdsInDto ->
-                browseArticleProblemsService.execute(query)
-            }
+            browseArticleProblemsService.execute(BrowseArticleProblemIdsInDto(articleRecord.articleId))
 
         /**
          * @see com.few.api.domain.article.usecase.ReadArticleUseCase

--- a/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookArticleService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookArticleService.kt
@@ -20,18 +20,20 @@ class WorkbookArticleService(
     private val articleDao: ArticleDao,
 ) {
     fun browseWorkbookArticles(query: BrowseWorkbookArticlesInDto): List<WorkBookArticleOutDto> {
-        return SelectWorkbookMappedArticleRecordsQuery(query.workbookId).let { query ->
-            articleDao.selectWorkbookMappedArticleRecords(query).map { record ->
-                WorkBookArticleOutDto(
-                    articleId = record.articleId,
-                    writerId = record.writerId,
-                    mainImageURL = record.mainImageURL,
-                    title = record.title,
-                    category = record.category,
-                    content = record.content,
-                    createdAt = record.createdAt
-                )
-            }
+        return articleDao.selectWorkbookMappedArticleRecords(
+            SelectWorkbookMappedArticleRecordsQuery(
+                query.workbookId
+            )
+        ).map { record ->
+            WorkBookArticleOutDto(
+                articleId = record.articleId,
+                writerId = record.writerId,
+                mainImageURL = record.mainImageURL,
+                title = record.title,
+                category = record.category,
+                content = record.content,
+                createdAt = record.createdAt
+            )
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookMemberService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookMemberService.kt
@@ -19,14 +19,12 @@ class WorkbookMemberService(
     private val memberDao: MemberDao,
 ) {
     fun browseWriterRecords(query: BrowseWriterRecordsInDto): List<WriterOutDto> {
-        return SelectWritersQuery(query.writerIds).let { query ->
-            memberDao.selectWriters(query).map { record ->
-                WriterOutDto(
-                    writerId = record.writerId,
-                    name = record.name,
-                    url = record.url
-                )
-            }
+        return memberDao.selectWriters(SelectWritersQuery(query.writerIds)).map { record ->
+            WriterOutDto(
+                writerId = record.writerId,
+                name = record.name,
+                url = record.url
+            )
         }
     }
 
@@ -35,8 +33,8 @@ class WorkbookMemberService(
      * value: writer list
      */
     fun browseWorkbookWriterRecords(query: BrowseWorkbookWriterRecordsInDto): Map<Long, List<WriterMappedWorkbookOutDto>> {
-        return BrowseWorkbookWritersQuery(query.workbookIds).let { query ->
-            memberDao.selectWriters(query).map { record ->
+        return memberDao.selectWriters(BrowseWorkbookWritersQuery(query.workbookIds))
+            .map { record ->
                 WriterMappedWorkbookOutDto(
                     workbookId = record.workbookId,
                     writerId = record.writerId,
@@ -44,6 +42,5 @@ class WorkbookMemberService(
                     url = record.url
                 )
             }.groupBy { it.workbookId }
-        }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookSubscribeService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/service/WorkbookSubscribeService.kt
@@ -3,8 +3,8 @@ package com.few.api.domain.workbook.service
 import com.few.api.domain.workbook.service.dto.BrowseMemberSubscribeWorkbooksInDto
 import com.few.api.domain.workbook.service.dto.BrowseMemberSubscribeWorkbooksOutDto
 import com.few.api.repo.dao.subscription.SubscriptionDao
-import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookActiveSubscription
-import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookInActiveSubscription
+import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookActiveSubscriptionQuery
+import com.few.api.repo.dao.subscription.query.SelectAllMemberWorkbookInActiveSubscriptionQuery
 import org.springframework.stereotype.Service
 
 @Service
@@ -14,14 +14,13 @@ class WorkbookSubscribeService(
 
     fun browseMemberSubscribeWorkbooks(dto: BrowseMemberSubscribeWorkbooksInDto): List<BrowseMemberSubscribeWorkbooksOutDto> {
         val inActiveSubscriptionRecords =
-            SelectAllMemberWorkbookInActiveSubscription(dto.memberId).let {
-                subscriptionDao.selectAllInActiveWorkbookSubscriptionStatus(it)
-            }
+            subscriptionDao.selectAllInActiveWorkbookSubscriptionStatus(
+                SelectAllMemberWorkbookInActiveSubscriptionQuery(dto.memberId)
+            )
 
-        val activeSubscriptionRecords =
-            SelectAllMemberWorkbookActiveSubscription(dto.memberId).let {
-                subscriptionDao.selectAllActiveWorkbookSubscriptionStatus(it)
-            }
+        val activeSubscriptionRecords = subscriptionDao.selectAllActiveWorkbookSubscriptionStatus(
+            SelectAllMemberWorkbookActiveSubscriptionQuery(dto.memberId)
+        )
 
         val subscriptionRecords = inActiveSubscriptionRecords + activeSubscriptionRecords
 

--- a/api/src/main/kotlin/com/few/api/domain/workbook/usecase/BrowseWorkbooksUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/usecase/BrowseWorkbooksUseCase.kt
@@ -13,7 +13,7 @@ import com.few.api.domain.workbook.usecase.service.order.AuthMainViewWorkbookOrd
 import com.few.api.domain.workbook.usecase.service.order.BasicWorkbookOrderDelegator
 import com.few.api.domain.workbook.usecase.service.order.WorkbookOrderDelegatorExecutor
 import com.few.api.repo.dao.workbook.WorkbookDao
-import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCount
+import com.few.api.repo.dao.workbook.query.BrowseWorkBookQueryWithSubscriptionCountQuery
 import com.few.api.web.support.ViewCategory
 import com.few.data.common.code.CategoryType
 import org.springframework.stereotype.Component
@@ -47,14 +47,14 @@ class BrowseWorkbooksUseCase(
 
     @Transactional
     fun execute(useCaseIn: BrowseWorkbooksUseCaseIn): BrowseWorkbooksUseCaseOut {
-        val workbookRecords = BrowseWorkBookQueryWithSubscriptionCount(useCaseIn.category.code).let { query ->
-            workbookDao.browseWorkBookWithSubscriptionCount(query)
-        }
+        val workbookRecords = workbookDao.browseWorkBookWithSubscriptionCount(
+            BrowseWorkBookQueryWithSubscriptionCountQuery(useCaseIn.category.code)
+        )
 
         val workbookIds = workbookRecords.map { it.id }
-        val writerRecords = BrowseWorkbookWriterRecordsInDto(workbookIds).let { query ->
-            workbookMemberService.browseWorkbookWriterRecords(query)
-        }
+        val writerRecords = workbookMemberService.browseWorkbookWriterRecords(
+            BrowseWorkbookWriterRecordsInDto(workbookIds)
+        )
 
         val workbookDetails = workbookRecords.map { record ->
             WorkBook(

--- a/api/src/main/kotlin/com/few/api/domain/workbook/usecase/ReadWorkbookUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/workbook/usecase/ReadWorkbookUseCase.kt
@@ -21,17 +21,17 @@ class ReadWorkbookUseCase(
     fun execute(useCaseIn: ReadWorkbookUseCaseIn): ReadWorkbookUseCaseOut {
         val workbookId = useCaseIn.workbookId
 
-        val workbookRecord = SelectWorkBookRecordQuery(workbookId).let { query ->
-            workbookDao.selectWorkBook(query) ?: throw NotFoundException("workbook.notfound.id")
-        }
+        val workbookRecord = workbookDao.selectWorkBook(SelectWorkBookRecordQuery(workbookId))
+            ?: throw NotFoundException("workbook.notfound.id")
 
-        val workbookMappedArticles = BrowseWorkbookArticlesInDto(workbookId).let { query ->
-            workbookArticleService.browseWorkbookArticles(query)
-        }
+        val workbookMappedArticles =
+            workbookArticleService.browseWorkbookArticles(BrowseWorkbookArticlesInDto(workbookId))
 
-        val writerRecords = BrowseWriterRecordsInDto(workbookMappedArticles.writerIds()).let { query ->
-            workbookMemberService.browseWriterRecords(query)
-        }
+        val writerRecords = workbookMemberService.browseWriterRecords(
+            BrowseWriterRecordsInDto(
+                workbookMappedArticles.writerIds()
+            )
+        )
 
         return ReadWorkbookUseCaseOut(
             id = workbookRecord.id,


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #372 

💁‍♂️ PR 내용
----
- 범위지정 함수 구현 통일

🙏 작업
----

- 범위지정 함수 구현 통일

## 범위지정 함수 사용 구분 

### 자신을 반환하는 경우
- apply(this) : 자신의 프로퍼티를 변경하고 자신을 반환하는 경우
- also(it): 자신을 파라미터로 자신의 프로퍼티를 활용하고 자신을 반환하는 경우

### 다른 값을 반환하는 경우
- run(this): 자신의 프로퍼티를 반환하는 경우
- let(it): 자신을 파라미터로 활용하여 람다를 수행한 결과를 반환하는 경우

- query, dto에 사용한 let 제거 -> 바로 넘기는 것으로 수정
- query, command suffix가 붙지 않는 객체 이름 통일

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
