### PR TITLE
[Refactor/#385] 설정 파일 정리

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,6 +1,11 @@
 
 import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 import java.util.Random
+
+tasks.withType(BootJar::class.java) {
+    loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC
+}
 
 dependencies {
     /** module */

--- a/api/src/main/kotlin/com/few/api/config/ApiConfig.kt
+++ b/api/src/main/kotlin/com/few/api/config/ApiConfig.kt
@@ -9,8 +9,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.scheduling.annotation.EnableAsync
-import org.springframework.web.servlet.config.annotation.EnableWebMvc
 
 @Configuration
 @ComponentScan(basePackages = [ApiConfig.BASE_PACKAGE])
@@ -21,8 +19,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc
     ImageStorageConfig::class,
     DocumentStorageConfig::class
 )
-@EnableWebMvc
-@EnableAsync
 @ConfigurationPropertiesScan(basePackages = [ApiConfig.BASE_PACKAGE])
 class ApiConfig {
     companion object {

--- a/api/src/main/kotlin/com/few/api/config/AsyncConfig.kt
+++ b/api/src/main/kotlin/com/few/api/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package com.few.api.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/api/src/main/kotlin/com/few/api/security/config/WebSecurityConfig.kt
+++ b/api/src/main/kotlin/com/few/api/security/config/WebSecurityConfig.kt
@@ -6,6 +6,7 @@ import com.few.api.security.filter.token.TokenAuthenticationFilter
 import com.few.api.security.handler.DelegatedAccessDeniedHandler
 import com.few.api.security.handler.DelegatedAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.ProviderManager
@@ -17,14 +18,13 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
-import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import org.springframework.web.filter.OncePerRequestFilter
 
 @EnableWebSecurity
-@Component
+@Configuration
 class WebSecurityConfig(
     private val authenticationEntryPoint: DelegatedAuthenticationEntryPoint,
     private val accessDeniedHandler: DelegatedAccessDeniedHandler,

--- a/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/response/ReadArticleResponse.kt
@@ -1,6 +1,5 @@
 package com.few.api.web.controller.article.response
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import java.net.URL
 import java.time.LocalDateTime
 
@@ -12,7 +11,6 @@ data class ReadArticleResponse(
     val content: String,
     val problemIds: List<Long>,
     val category: String,
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     val createdAt: LocalDateTime,
     val views: Long,
     val workbooks: List<WorkbookInfo> = emptyList(),

--- a/api/src/main/kotlin/com/few/api/web/controller/workbook/article/response/ReadWorkBookArticleResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/workbook/article/response/ReadWorkBookArticleResponse.kt
@@ -1,6 +1,5 @@
 package com.few.api.web.controller.workbook.article.response
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import com.few.api.domain.workbook.article.dto.ReadWorkBookArticleOut
 import com.few.api.web.controller.workbook.response.WriterInfo
 import java.time.LocalDateTime
@@ -12,7 +11,6 @@ data class ReadWorkBookArticleResponse(
     val content: String,
     val problemIds: List<Long>,
     val category: String,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     val createdAt: LocalDateTime,
     val day: Long,
 ) {

--- a/api/src/main/kotlin/com/few/api/web/controller/workbook/response/BrowseWorkBooksResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/workbook/response/BrowseWorkBooksResponse.kt
@@ -1,6 +1,5 @@
 package com.few.api.web.controller.workbook.response
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import java.net.URL
 import java.time.LocalDateTime
 
@@ -14,7 +13,6 @@ data class BrowseWorkBookInfo(
     val title: String,
     val description: String,
     val category: String,
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     val createdAt: LocalDateTime,
     val writers: List<WriterInfo>,
     val subscriberCount: Long,

--- a/api/src/main/kotlin/com/few/api/web/controller/workbook/response/ReadWorkBookResponse.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/workbook/response/ReadWorkBookResponse.kt
@@ -1,6 +1,5 @@
 package com.few.api.web.controller.workbook.response
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import com.few.api.domain.workbook.usecase.dto.ReadWorkbookUseCaseOut
 import java.net.URL
 import java.time.LocalDateTime
@@ -11,7 +10,6 @@ data class ReadWorkBookResponse(
     val title: String,
     val description: String,
     val category: String,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     val createdAt: LocalDateTime,
     val writers: List<WriterInfo>,
     val articles: List<ArticleInfo>,


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #385 

💁‍♂️ PR 내용
----
- 설정 파일 정리 

🙏 작업
----
- 기존에 EnableWebMvc를 제거하면 배포시 아래와 같은 로그로 종료되는 문제가 있었습니다.
    - 이슈를 봤을 때 [nested-jar-support](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#nested-jar-support) 관련된 문제였고 bootJar 옵션에 `loaderImplementation = org.springframework.boot.loader.tools.LoaderImplementation.CLASSIC`를 추가해서 해결하였습니다.
    - 그 결과 해당 이슈 때문에 제거하지 못했던 LocalDataTime의 JsonFormat을 제거하였습니다.

- 추가적으로 설정 파일 분리 및 정리도 수행하였습니다.

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.web.servlet.HandlerMapping]: Factory method 'resourceHandlerMapping' threw exception with message: Uncaught exception during scan
--
at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:177) ~[spring-beans-6.1.6.jar!/:6.1.6]
at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:644) ~[spring-beans-6.1.6.jar!/:6.1.6]
... 74 common frames omitted
Caused by: io.github.classgraph.ClassGraphException: Uncaught exception during scan
at io.github.classgraph.ClassGraph.scan(ClassGraph.java:1558) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.ClassGraph.scan(ClassGraph.java:1575) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.ClassGraph.scan(ClassGraph.java:1588) ~[classgraph-4.8.117.jar!/:4.8.117]
at org.webjars.WebJarAssetLocator.scanForWebJars(WebJarAssetLocator.java:188) ~[webjars-locator-core-0.55.jar!/:na]
at org.webjars.WebJarAssetLocator.<init>(WebJarAssetLocator.java:210) ~[webjars-locator-core-0.55.jar!/:na]
at org.webjars.WebJarAssetLocator.<init>(WebJarAssetLocator.java:194) ~[webjars-locator-core-0.55.jar!/:na]
at org.springframework.web.servlet.resource.WebJarsResourceResolver.<init>(WebJarsResourceResolver.java:63) ~[spring-webmvc-6.1.6.jar!/:6.1.6]
at org.springframework.web.servlet.config.annotation.ResourceChainRegistration.getResourceResolvers(ResourceChainRegistration.java:114) ~[spring-webmvc-6.1.6.jar!/:6.1.6]
at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration.getRequestHandler(ResourceHandlerRegistration.java:235) ~[spring-webmvc-6.1.6.jar!/:6.1.6]
at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.getRequestHandler(ResourceHandlerRegistry.java:178) ~[spring-webmvc-6.1.6.jar!/:6.1.6]
at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.getHandlerMapping(ResourceHandlerRegistry.java:168) ~[spring-webmvc-6.1.6.jar!/:6.1.6]
at org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport.resourceHandlerMapping(WebMvcConfigurationSupport.java:589) ~[spring-webmvc-6.1.6.jar!/:6.1.6]
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[na:na]
at java.base/java.lang.reflect.Method.invoke(Method.java:577) ~[na:na]
at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:140) ~[spring-beans-6.1.6.jar!/:6.1.6]
... 75 common frames omitted
Caused by: java.lang.UnsupportedOperationException: Unable to resolve nested path
at org.springframework.boot.loader.nio.file.NestedPath.resolve(NestedPath.java:130) ~[app.jar:na]
at java.base/java.nio.file.Path.resolve(Path.java:515) ~[na:na]
at io.github.classgraph.Scanner$2.newInstance(Scanner.java:479) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner$2.newInstance(Scanner.java:388) ~[classgraph-4.8.117.jar!/:4.8.117]
at nonapi.io.github.classgraph.concurrency.SingletonMap.get(SingletonMap.java:189) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner$3.processWorkUnit(Scanner.java:583) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner$3.processWorkUnit(Scanner.java:574) ~[classgraph-4.8.117.jar!/:4.8.117]
at nonapi.io.github.classgraph.concurrency.WorkQueue.runWorkLoop(WorkQueue.java:246) ~[classgraph-4.8.117.jar!/:4.8.117]
at nonapi.io.github.classgraph.concurrency.WorkQueue.runWorkQueue(WorkQueue.java:161) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner.processWorkUnits(Scanner.java:342) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner.openClasspathElementsThenScan(Scanner.java:1057) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner.call(Scanner.java:1156) ~[classgraph-4.8.117.jar!/:4.8.117]
at io.github.classgraph.Scanner.call(Scanner.java:83) ~[classgraph-4.8.117.jar!/:4.8.117]
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
