### PR TITLE
[Feat/#384] 구독 중복 신청 방지 위한 락 구현

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
@@ -18,6 +18,21 @@ import java.time.LocalDateTime
 class SubscriptionDao(
     private val dslContext: DSLContext,
 ) {
+    fun getLock(memberId: Long, workbookId: Long, timeout: Int = 5): Boolean {
+        return dslContext.fetch(
+            """
+            SELECT GET_LOCK(CONCAT('subscription_', $memberId, '_', $workbookId), $timeout);
+            """
+        ).into(Int::class.java).first() == 1
+    }
+
+    fun releaseLock(memberId: Long, workbookId: Long): Boolean {
+        return dslContext.fetch(
+            """
+            SELECT RELEASE_LOCK(CONCAT('subscription_', $memberId, '_', $workbookId));
+            """
+        ).into(Int::class.java).first() == 1
+    }
 
     fun insertWorkbookSubscription(command: InsertWorkbookSubscriptionCommand) {
         insertWorkbookSubscriptionCommand(command)

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,11 +13,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 
     /** jwt */
     implementation("io.jsonwebtoken:jjwt-api:${DependencyVersion.JWT}")
     implementation("io.jsonwebtoken:jjwt-impl:${DependencyVersion.JWT}")
     implementation("io.jsonwebtoken:jjwt-jackson:${DependencyVersion.JWT}")
+
+    /** aspectj */
+    implementation("org.aspectj:aspectjweaver:1.9.5")
 
     /** scrimage */
     implementation("com.sksamuel.scrimage:scrimage-core:${DependencyVersion.SCRIMAGE}")

--- a/api/src/main/kotlin/com/few/api/config/ApiConfig.kt
+++ b/api/src/main/kotlin/com/few/api/config/ApiConfig.kt
@@ -8,7 +8,6 @@ import com.few.storage.image.config.ImageStorageConfig
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.context.annotation.Import
 
 @Configuration

--- a/api/src/main/kotlin/com/few/api/config/ApiConfig.kt
+++ b/api/src/main/kotlin/com/few/api/config/ApiConfig.kt
@@ -8,6 +8,7 @@ import com.few.storage.image.config.ImageStorageConfig
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.web.servlet.config.annotation.EnableWebMvc
@@ -23,6 +24,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc
 )
 @EnableWebMvc
 @EnableAsync
+@EnableAspectJAutoProxy
 @ConfigurationPropertiesScan(basePackages = [ApiConfig.BASE_PACKAGE])
 class ApiConfig {
     companion object {

--- a/api/src/main/kotlin/com/few/api/config/AspectConfig.kt
+++ b/api/src/main/kotlin/com/few/api/config/AspectConfig.kt
@@ -1,0 +1,8 @@
+package com.few.api.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+
+@Configuration
+@EnableAspectJAutoProxy
+class AspectConfig

--- a/api/src/main/kotlin/com/few/api/domain/common/lock/LockAspect.kt
+++ b/api/src/main/kotlin/com/few/api/domain/common/lock/LockAspect.kt
@@ -1,0 +1,77 @@
+package com.few.api.domain.common.lock
+
+import com.few.api.domain.subscription.usecase.dto.SubscribeWorkbookUseCaseIn
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.AfterThrowing
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.aspectj.lang.annotation.Pointcut
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LockAspect(
+    private val subscriptionDao: SubscriptionDao,
+) {
+    private val log = KotlinLogging.logger {}
+
+    @Pointcut("@annotation(com.few.api.domain.common.lock.LockFor)")
+    fun lockPointcut() {}
+
+    @Before("lockPointcut()")
+    fun before(joinPoint: JoinPoint) {
+        getLockFor(joinPoint).run {
+            when (this.identifier) {
+                LockIdentifier.SUBSCRIPTION_MEMBER_ID_WORKBOOK_ID -> {
+                    val useCaseIn = joinPoint.args[0] as SubscribeWorkbookUseCaseIn
+                    getSubscriptionMemberIdAndWorkBookIdLock(useCaseIn)
+                }
+            }
+        }
+    }
+
+    private fun getSubscriptionMemberIdAndWorkBookIdLock(useCaseIn: SubscribeWorkbookUseCaseIn) {
+        subscriptionDao.getLock(useCaseIn.memberId, useCaseIn.workbookId).run {
+            if (!this) {
+                throw IllegalStateException("Already in progress for ${useCaseIn.memberId}'s subscription to ${useCaseIn.workbookId}")
+            }
+            log.debug { "Lock acquired for ${useCaseIn.memberId}'s subscription to ${useCaseIn.workbookId}" }
+        }
+    }
+
+    @AfterReturning("lockPointcut()")
+    fun afterReturning(joinPoint: JoinPoint) {
+        getLockFor(joinPoint).run {
+            when (this.identifier) {
+                LockIdentifier.SUBSCRIPTION_MEMBER_ID_WORKBOOK_ID -> {
+                    val useCaseIn = joinPoint.args[0] as SubscribeWorkbookUseCaseIn
+                    releaseSubscriptionMemberIdAndWorkBookIdLock(useCaseIn)
+                }
+            }
+        }
+    }
+
+    @AfterThrowing("lockPointcut()")
+    fun afterThrowing(joinPoint: JoinPoint) {
+        getLockFor(joinPoint).run {
+            when (this.identifier) {
+                LockIdentifier.SUBSCRIPTION_MEMBER_ID_WORKBOOK_ID -> {
+                    val useCaseIn = joinPoint.args[0] as SubscribeWorkbookUseCaseIn
+                    releaseSubscriptionMemberIdAndWorkBookIdLock(useCaseIn)
+                }
+            }
+        }
+    }
+
+    private fun getLockFor(joinPoint: JoinPoint) =
+        (joinPoint.signature as MethodSignature).method.getAnnotation(LockFor::class.java)
+
+    private fun releaseSubscriptionMemberIdAndWorkBookIdLock(useCaseIn: SubscribeWorkbookUseCaseIn) {
+        subscriptionDao.releaseLock(useCaseIn.memberId, useCaseIn.workbookId)
+        log.debug { "Lock released for ${useCaseIn.memberId}'s subscription to ${useCaseIn.workbookId}" }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/common/lock/LockFor.kt
+++ b/api/src/main/kotlin/com/few/api/domain/common/lock/LockFor.kt
@@ -1,0 +1,7 @@
+package com.few.api.domain.common.lock
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LockFor(
+    val identifier: LockIdentifier,
+)

--- a/api/src/main/kotlin/com/few/api/domain/common/lock/LockIdentifier.kt
+++ b/api/src/main/kotlin/com/few/api/domain/common/lock/LockIdentifier.kt
@@ -1,0 +1,8 @@
+package com.few.api.domain.common.lock
+
+enum class LockIdentifier {
+    /**
+     * 구독 테이블에 멤버와 워크북을 기준으로 락을 건다.
+     */
+    SUBSCRIPTION_MEMBER_ID_WORKBOOK_ID,
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/usecase/SubscribeWorkbookUseCase.kt
@@ -1,5 +1,7 @@
 package com.few.api.domain.subscription.usecase
 
+import com.few.api.domain.common.lock.LockFor
+import com.few.api.domain.common.lock.LockIdentifier
 import com.few.api.domain.subscription.event.dto.WorkbookSubscriptionEvent
 import com.few.api.repo.dao.subscription.SubscriptionDao
 import com.few.api.repo.dao.subscription.command.InsertWorkbookSubscriptionCommand
@@ -21,6 +23,7 @@ class SubscribeWorkbookUseCase(
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
 
+    @LockFor(LockIdentifier.SUBSCRIPTION_MEMBER_ID_WORKBOOK_ID)
     @Transactional
     fun execute(useCaseIn: SubscribeWorkbookUseCaseIn) {
         val subTargetWorkbookId = useCaseIn.workbookId


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #384 

💁‍♂️ PR 내용
----
- 구독 중복 신청 방지

🙏 작업
----
- 구독 테이블에 유니크 조건이 제거되어 중복 구독 신청이되는 문제를 발견하였습니다.

<img width="1728" alt="스크린샷 2024-09-04 오전 10 41 37" src="https://github.com/user-attachments/assets/c3fbe1de-667b-44c1-ad97-5782295accdc">

- 네임드 락을 사용하여 해당 문제를 해결하였습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
