### PR TITLE
[Refactor/#398] 멤버 탈퇴시 구독 정보 삭제될 수 있도록 수정

### DIFF
--- a/api/src/main/kotlin/com/few/api/domain/member/subscription/MemberSubscriptionService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/member/subscription/MemberSubscriptionService.kt
@@ -1,0 +1,23 @@
+package com.few.api.domain.member.subscription
+
+import com.few.api.domain.member.subscription.dto.DeleteSubscriptionDto
+import com.few.api.repo.dao.subscription.SubscriptionDao
+import com.few.api.repo.dao.subscription.command.UpdateDeletedAtInAllSubscriptionCommand
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MemberSubscriptionService(
+    private val subscriptionDao: SubscriptionDao,
+) {
+
+    @Transactional
+    fun deleteSubscription(dto: DeleteSubscriptionDto) {
+        subscriptionDao.updateDeletedAtInAllSubscription(
+            UpdateDeletedAtInAllSubscriptionCommand(
+                memberId = dto.memberId,
+                opinion = dto.opinion
+            )
+        )
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/member/subscription/dto/DeleteSubscriptionDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/member/subscription/dto/DeleteSubscriptionDto.kt
@@ -1,0 +1,6 @@
+package com.few.api.domain.member.subscription.dto
+
+data class DeleteSubscriptionDto(
+    val memberId: Long,
+    val opinion: String = "withdrawal",
+)

--- a/api/src/main/kotlin/com/few/api/domain/member/usecase/DeleteMemberUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/member/usecase/DeleteMemberUseCase.kt
@@ -1,16 +1,18 @@
 package com.few.api.domain.member.usecase
 
+import com.few.api.domain.member.subscription.MemberSubscriptionService
+import com.few.api.domain.member.subscription.dto.DeleteSubscriptionDto
 import com.few.api.domain.member.usecase.dto.DeleteMemberUseCaseIn
 import com.few.api.domain.member.usecase.dto.DeleteMemberUseCaseOut
 import com.few.api.repo.dao.member.MemberDao
 import com.few.api.repo.dao.member.command.DeleteMemberCommand
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.util.*
 
 @Component
 class DeleteMemberUseCase(
     private val memberDao: MemberDao,
+    private val memberSubscriptionService: MemberSubscriptionService,
 ) {
     @Transactional
     fun execute(useCaseIn: DeleteMemberUseCaseIn): DeleteMemberUseCaseOut {
@@ -20,6 +22,12 @@ class DeleteMemberUseCase(
             )
         )
 
+        memberSubscriptionService.deleteSubscription(
+            DeleteSubscriptionDto(
+                memberId = useCaseIn.memberId,
+                opinion = "cancel"
+            )
+        )
         return DeleteMemberUseCaseOut(true)
     }
 }


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #398 

💁‍♂️ PR 내용
----
- 멤버 탈퇴시 구독 정보 삭제될 수 있도록 수정

🙏 작업
----
- 멤버 탈퇴시 구독 정보 삭제될 수 있도록 수정

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
