### PR TITLE
[Fix/#401] 하루안에 재구독시 아티클 중복 전송 및 진행률 추가되는 문제 해결

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectSubscriptionQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectSubscriptionQuery.kt
@@ -1,0 +1,6 @@
+package com.few.api.repo.dao.subscription.query
+
+data class SelectSubscriptionQuery(
+    val memberId: Long,
+    val workbookId: Long,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/SubscriptionTimeRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/SubscriptionTimeRecord.kt
@@ -1,0 +1,11 @@
+package com.few.api.repo.dao.subscription.record
+
+import java.time.LocalDateTime
+
+data class SubscriptionTimeRecord(
+    val memberId: Long,
+    val workbookId: Long,
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime,
+    val sendAt: LocalDateTime?,
+)

--- a/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
+++ b/api-repo/src/test/kotlin/com/few/api/repo/explain/subscription/SubscriptionDaoExplainGenerateTest.kt
@@ -201,4 +201,18 @@ class SubscriptionDaoExplainGenerateTest : JooqTestSpec() {
 
         ResultGenerator.execute(query, explain, "selectAllSubscriptionSendStatusQueryExplain")
     }
+
+    @Test
+    fun selectSubscriptionTimeRecordQueryExplain() {
+        val query = subscriptionDao.selectSubscriptionTimeRecordQuery(
+            SelectSubscriptionQuery(
+                memberId = 1L,
+                workbookId = 1L
+            )
+        )
+
+        val explain = ExplainGenerator.execute(dslContext, query)
+
+        ResultGenerator.execute(query, explain, "selectSubscriptionTimeRecordQueryExplain")
+    }
 }

--- a/api/src/main/kotlin/com/few/api/domain/subscription/event/WorkbookSubscriptionAfterCompletionEventListener.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/event/WorkbookSubscriptionAfterCompletionEventListener.kt
@@ -3,8 +3,6 @@ package com.few.api.domain.subscription.event
 import com.few.api.domain.subscription.event.dto.WorkbookSubscriptionEvent
 import com.few.api.domain.subscription.handler.SendWorkbookArticleAsyncHandler
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -14,7 +12,6 @@ class WorkbookSubscriptionAfterCompletionEventListener(
 ) {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun handleEvent(event: WorkbookSubscriptionEvent) {
         sendWorkbookArticleAsyncHandler.sendWorkbookArticle(
             event.memberId,

--- a/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/writer/WorkBookSubscriberWriter.kt
@@ -89,6 +89,8 @@ class WorkBookSubscriberWriter(
             updateQueries.add(
                 dslContext.update(Subscription.SUBSCRIPTION)
                     .set(Subscription.SUBSCRIPTION.PROGRESS, updateTargetMemberRecord.updatedProgress)
+                    .set(Subscription.SUBSCRIPTION.MODIFIED_AT, LocalDateTime.now())
+                    .set(Subscription.SUBSCRIPTION.SEND_AT, LocalDateTime.now())
                     .where(Subscription.SUBSCRIPTION.MEMBER_ID.eq(updateTargetMemberRecord.memberId))
                     .and(Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(updateTargetMemberRecord.targetWorkBookId))
             )
@@ -101,6 +103,8 @@ class WorkBookSubscriberWriter(
             receiveLastDayQueries.add(
                 dslContext.update(Subscription.SUBSCRIPTION)
                     .set(Subscription.SUBSCRIPTION.DELETED_AT, LocalDateTime.now())
+                    .set(Subscription.SUBSCRIPTION.MODIFIED_AT, LocalDateTime.now())
+                    .set(Subscription.SUBSCRIPTION.SEND_AT, LocalDateTime.now())
                     .set(Subscription.SUBSCRIPTION.UNSUBS_OPINION, "receive.all")
                     .where(Subscription.SUBSCRIPTION.MEMBER_ID.eq(receiveLastDayMember.memberId))
                     .and(Subscription.SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(receiveLastDayMember.targetWorkBookId))

--- a/data/db/migration/entity/V1.00.0.24__add_subscription_send_at.sql
+++ b/data/db/migration/entity/V1.00.0.24__add_subscription_send_at.sql
@@ -1,0 +1,2 @@
+-- 구독 발송 시간 컬럼 추가
+ALTER TABLE SUBSCRIPTION ADD COLUMN send_at TIMESTAMP;


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #401 

💁‍♂️ PR 내용
----
- 하루안에 재구독시 아티클 중복 전송 및 진행률 추가되는 문제 해결

🙏 작업
----
- 전송 시간을 기록하는 컬럼 추가
- 구독 이벤트 처리 수정
    - 핸들러에 트랜잭션 부여
    - 동일 날짜에 재구독시 아티클 전송하지 않도록 수정

🙈 PR 참고 사항
----

📸 스크린샷
----
<img width="1349" alt="스크린샷 2024-09-15 오후 10 32 47" src="https://github.com/user-attachments/assets/a4f2ed82-e419-4efd-a2cf-c174fcc15e31">

구독후 전송시간 기록, 진행률 업데이트 확인하였습니다.

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
