### PR TITLE
[Fix/#403] 멤버 탈퇴시 구독 정보 의견 기록 수정 

### DIFF
--- a/api/src/main/kotlin/com/few/api/domain/member/usecase/DeleteMemberUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/member/usecase/DeleteMemberUseCase.kt
@@ -24,8 +24,7 @@ class DeleteMemberUseCase(
 
         memberSubscriptionService.deleteSubscription(
             DeleteSubscriptionDto(
-                memberId = useCaseIn.memberId,
-                opinion = "cancel"
+                memberId = useCaseIn.memberId
             )
         )
         return DeleteMemberUseCaseOut(true)


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #403 

💁‍♂️ PR 내용
----
- 멤버 탈퇴시 구독 정보 의견 기록 수정 

🙏 작업
----
- 기본값인 withdrawal 사용하도록 수정

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
