### PR TITLE
[Fix/#406] 매일 받기 설정한 구독 조회되지 않는 문제 해결

### DIFF
--- a/batch/src/main/kotlin/com/few/batch/service/article/reader/WorkBookSubscriberReader.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/reader/WorkBookSubscriberReader.kt
@@ -3,7 +3,10 @@ package com.few.batch.service.article.reader
 import com.few.batch.data.common.code.BatchDayCode
 import com.few.batch.service.article.dto.WorkBookSubscriberItem
 import jooq.jooq_dsl.tables.Subscription.SUBSCRIPTION
+import jooq.jooq_dsl.tables.records.SubscriptionRecord
+import org.jooq.Condition
 import org.jooq.DSLContext
+import org.jooq.TableField
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.DayOfWeek
@@ -23,9 +26,9 @@ class WorkBookSubscriberReader(
         val date = LocalDate.now(ZoneId.of("Asia/Seoul"))
         val sendDay =
             if ((date.dayOfWeek == DayOfWeek.SATURDAY) || (date.dayOfWeek == DayOfWeek.SUNDAY)) {
-                BatchDayCode.MON_TUE_WED_THU_FRI_SAT_SUN.code
+                BatchDayCode.MON_TUE_WED_THU_FRI_SAT_SUN
             } else {
-                BatchDayCode.MON_TUE_WED_THU_FRI.code
+                BatchDayCode.MON_TUE_WED_THU_FRI
             }
 
         return dslContext.select(
@@ -35,9 +38,17 @@ class WorkBookSubscriberReader(
         )
             .from(SUBSCRIPTION)
             .where(SUBSCRIPTION.SEND_TIME.eq(time))
-            .and(SUBSCRIPTION.SEND_DAY.eq(sendDay))
+            .and(sendDayCondition(SUBSCRIPTION.SEND_DAY, sendDay))
             .and(SUBSCRIPTION.TARGET_MEMBER_ID.isNull)
             .and(SUBSCRIPTION.DELETED_AT.isNull)
             .fetchInto(WorkBookSubscriberItem::class.java)
+    }
+
+    private fun sendDayCondition(sendDayField: TableField<SubscriptionRecord, String>, sendDayCode: BatchDayCode): Condition {
+        return if (sendDayCode == BatchDayCode.MON_TUE_WED_THU_FRI_SAT_SUN) {
+            sendDayField.eq(BatchDayCode.MON_TUE_WED_THU_FRI.code).or(sendDayField.eq(BatchDayCode.MON_TUE_WED_THU_FRI_SAT_SUN.code))
+        } else {
+            sendDayField.eq(sendDayCode.code)
+        }
     }
 }


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #406 

💁‍♂️ PR 내용
----
- 매일 받기 설정한 구독 조회되지 않는 문제 해결

🙏 작업
----
- 기존에 평일 조회 쿼리에서 평일의 조건인 `0011111`만 조건으로 설정하여 매일인 `1111111`를 조회하지 못하는 문제가 있어 `or`을 통해 해결하였습니다.

수정된 쿼리 예시입니다.

```
select `SUBSCRIPTION`.`MEMBER_ID`          as `memberId`,
       `SUBSCRIPTION`.`TARGET_WORKBOOK_ID` as `targetWorkBookId`,
       `SUBSCRIPTION`.`PROGRESS`           as `progress`
from `SUBSCRIPTION`
where (`SUBSCRIPTION`.`SEND_TIME` = {t '09:00:00'} and
       (`SUBSCRIPTION`.`SEND_DAY` = '0011111' or `SUBSCRIPTION`.`SEND_DAY` = '1111111') and
       `SUBSCRIPTION`.`TARGET_MEMBER_ID` is null and `SUBSCRIPTION`.`DELETED_AT` is null);
```

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
