### PR TITLE
[Refactor/#415] 이메일 전송 목적에 따른 이메일 전송 프로바이더 분리 및 전송 프로바이더 설정할 수 있도록 수정 그리고 전송 이메일 식별자 추가

### DIFF
--- a/api/src/test/kotlin/com/few/api/domain/member/usecase/SaveMemberUseCaseTest.kt
+++ b/api/src/test/kotlin/com/few/api/domain/member/usecase/SaveMemberUseCaseTest.kt
@@ -40,7 +40,7 @@ class SaveMemberUseCaseTest : BehaviorSpec({
             val token = "encryptedToken"
             every { idEncryption.encrypt(any()) } returns token
 
-            every { sendAuthEmailService.send(any()) } returns Unit
+            every { sendAuthEmailService.send(any()) } returns "messageId"
 
             then("인증 이메일 발송 성공 응답을 반환한다") {
                 val useCaseOut = useCase.execute(useCaseIn)
@@ -64,7 +64,7 @@ class SaveMemberUseCaseTest : BehaviorSpec({
             val token = "encryptedToken"
             every { idEncryption.encrypt(any()) } returns token
 
-            every { sendAuthEmailService.send(any()) } returns Unit
+            every { sendAuthEmailService.send(any()) } returns "messageId"
 
             then("인증 이메일 발송 성공 응답을 반환한다") {
                 val useCaseOut = useCase.execute(useCaseIn)
@@ -90,7 +90,7 @@ class SaveMemberUseCaseTest : BehaviorSpec({
             val token = "encryptedToken"
             every { idEncryption.encrypt(any()) } returns token
 
-            every { sendAuthEmailService.send(any()) } returns Unit
+            every { sendAuthEmailService.send(any()) } returns "messageId"
 
             then("인증 이메일 발송 성공 응답을 반환한다") {
                 val useCaseOut = useCase.execute(useCaseIn)

--- a/email/src/main/kotlin/com/few/email/sender/EmailSender.kt
+++ b/email/src/main/kotlin/com/few/email/sender/EmailSender.kt
@@ -6,15 +6,23 @@ import org.springframework.boot.autoconfigure.mail.MailProperties
 
 abstract class EmailSender<T : SendMailArgs<*, *>>(
     private val mailProperties: MailProperties,
-    private val emailSendProvider: EmailSendProvider,
+    private val defaultEmailSendProvider: EmailSendProvider,
 ) {
 
-    fun send(args: T) {
+    fun send(args: T, emailSendProvider: EmailSendProvider? = null): String {
         val from = mailProperties.username
         val to = args.to
         val subject = args.subject
         val message = getHtml(args)
-        emailSendProvider.sendEmail("FEW Letter <$from>", to, subject, message)
+        return emailSendProvider?.sendEmail("FEW Letter <$from>", to, subject, message)
+            ?: run {
+                defaultEmailSendProvider.sendEmail(
+                    "FEW Letter <$from>",
+                    to,
+                    subject,
+                    message
+                )
+            }
     }
 
     abstract fun getHtml(args: T): String

--- a/email/src/main/kotlin/com/few/email/sender/provider/ArticleAwsSESEmailSendProvider.kt
+++ b/email/src/main/kotlin/com/few/email/sender/provider/ArticleAwsSESEmailSendProvider.kt
@@ -1,0 +1,17 @@
+package com.few.email.sender.provider
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
+import org.springframework.stereotype.Component
+
+@Component
+class ArticleAwsSESEmailSendProvider(
+    amazonSimpleEmailService: AmazonSimpleEmailService,
+    javaEmailSendProvider: JavaEmailSendProvider,
+) : AwsSESEmailSendProvider(
+    amazonSimpleEmailService,
+    javaEmailSendProvider
+) {
+    override fun getWithConfigurationSetName(): String {
+        return "few-article-configuration-set"
+    }
+}

--- a/email/src/main/kotlin/com/few/email/sender/provider/AwsSESEmailSendProvider.kt
+++ b/email/src/main/kotlin/com/few/email/sender/provider/AwsSESEmailSendProvider.kt
@@ -27,7 +27,7 @@ class AwsSESEmailSendProvider(
             .withSource(from)
             .withDestination(destination)
             .withMessage(sendMessage)
-            .withConfigurationSetName("few-configuration-set")
+            .withConfigurationSetName(getWithConfigurationSetName())
 
         runCatching {
             amazonSimpleEmailService.sendEmail(sendEmailRequest).messageId
@@ -49,5 +49,12 @@ class AwsSESEmailSendProvider(
         }.let {
             return it.getOrThrow()
         }
+    }
+
+    /**
+     * Default configuration set name is "few-configuration-set"
+     */
+    fun getWithConfigurationSetName(): String {
+        return "few-configuration-set"
     }
 }

--- a/email/src/main/kotlin/com/few/email/sender/provider/EmailSendProvider.kt
+++ b/email/src/main/kotlin/com/few/email/sender/provider/EmailSendProvider.kt
@@ -1,5 +1,8 @@
 package com.few.email.sender.provider
 
 interface EmailSendProvider {
-    fun sendEmail(from: String, to: String, subject: String, message: String)
+    /**
+     * @return 전송한 이메일 식벽을 위한 값
+     */
+    fun sendEmail(from: String, to: String, subject: String, message: String): String
 }

--- a/email/src/main/kotlin/com/few/email/sender/provider/JavaEmailSendProvider.kt
+++ b/email/src/main/kotlin/com/few/email/sender/provider/JavaEmailSendProvider.kt
@@ -13,7 +13,7 @@ class JavaEmailSendProvider(
     companion object {
         private const val UTF_8 = "utf-8"
     }
-    override fun sendEmail(from: String, to: String, subject: String, message: String) {
+    override fun sendEmail(from: String, to: String, subject: String, message: String): String {
         val sendMessage: MimeMessage = emailSender.createMimeMessage()
         val helper = MimeMessageHelper(sendMessage, UTF_8)
         try {
@@ -25,5 +25,6 @@ class JavaEmailSendProvider(
             throw RuntimeException(e)
         }
         emailSender.send(sendMessage)
+        return sendMessage.messageID
     }
 }

--- a/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
+++ b/email/src/main/kotlin/com/few/email/service/article/SendArticleEmailService.kt
@@ -1,7 +1,7 @@
 package com.few.email.service.article
 
 import com.few.email.sender.EmailSender
-import com.few.email.sender.provider.EmailSendProvider
+import com.few.email.sender.provider.ArticleAwsSESEmailSendProvider
 import com.few.email.service.article.dto.SendArticleEmailArgs
 import org.springframework.boot.autoconfigure.mail.MailProperties
 import org.springframework.stereotype.Component
@@ -13,7 +13,7 @@ import java.util.*
 @Component
 class SendArticleEmailService(
     mailProperties: MailProperties,
-    emailSendProvider: EmailSendProvider,
+    emailSendProvider: ArticleAwsSESEmailSendProvider,
     private val templateEngine: TemplateEngine,
 ) : EmailSender<SendArticleEmailArgs>(mailProperties, emailSendProvider) {
 


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #415 

💁‍♂️ PR 내용
----
- 이메일 전송 목적에 따른 이메일 전송 프로바이더 분리 및 전송 프로바이더 설정할 수 있도록 수정 그리고 전송 이메일 식별자 추가

🙏 작업
----
- 전송 이메일 식별자 추가를 위해 이메일 전송 프로바이더 분리하였습니다
- 기본으로 설정된 이메일 전송 프로바이더 말고 전송시 프로바이더를 설정할 수 있도록 수정하였습니다.
- 전송한 이메일 식별 위한 식별자를 추가하였습니다.

🙈 PR 참고 사항
----
![스크린샷 2024-09-20 오후 4 04 50](https://github.com/user-attachments/assets/76de0791-b7a0-4ea5-a0b4-c83324be8414)

SES에서 제공하는 값은 고유하다고 하고

![스크린샷 2024-09-20 오후 4 06 04](https://github.com/user-attachments/assets/e25fcee4-8563-40cf-a191-03e2e3d7a6e6)

JavaMailSender의 경우에는 고유하다는 것을 보장한다는 코멘트는 없네요..


📸 스크린샷
----
![스크린샷 2024-09-20 오후 3 48 58](https://github.com/user-attachments/assets/77dcf74a-438e-41a5-9f78-dca897ce6c7f)

JavaMailSender messageId 예

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
