### PR TITLE
[Fix/#417] 멤버가 구독 전송 시간을 변경한 상태로 추가 구독하여도 기본 구독 전송 시간으로 생성되는 문제 해결

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/SubscriptionDao.kt
@@ -42,6 +42,8 @@ class SubscriptionDao(
         dslContext.insertInto(SUBSCRIPTION)
             .set(SUBSCRIPTION.MEMBER_ID, command.memberId)
             .set(SUBSCRIPTION.TARGET_WORKBOOK_ID, command.workbookId)
+            .set(SUBSCRIPTION.SEND_DAY, command.sendDay)
+            .set(SUBSCRIPTION.SEND_TIME, command.sendTime)
 
     fun reSubscribeWorkbookSubscription(command: InsertWorkbookSubscriptionCommand) {
         reSubscribeWorkBookSubscriptionCommand(command)
@@ -53,6 +55,8 @@ class SubscriptionDao(
             .set(SUBSCRIPTION.DELETED_AT, null as LocalDateTime?)
             .set(SUBSCRIPTION.UNSUBS_OPINION, null as String?)
             .set(SUBSCRIPTION.MODIFIED_AT, LocalDateTime.now())
+            .set(SUBSCRIPTION.SEND_DAY, command.sendDay)
+            .set(SUBSCRIPTION.SEND_TIME, command.sendTime)
             .where(SUBSCRIPTION.MEMBER_ID.eq(command.memberId))
             .and(SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(command.workbookId))
 
@@ -282,4 +286,20 @@ class SubscriptionDao(
             .from(SUBSCRIPTION)
             .where(SUBSCRIPTION.MEMBER_ID.eq(query.memberId))
             .and(SUBSCRIPTION.TARGET_WORKBOOK_ID.eq(query.workbookId))
+
+    fun selectSubscriptionSendStatus(query: SelectSubscriptionSendStatusQuery): List<SubscriptionSendStatus> {
+        return selectSubscriptionSendStatusQuery(query)
+            .fetchInto(SubscriptionSendStatus::class.java)
+    }
+
+    fun selectSubscriptionSendStatusQuery(query: SelectSubscriptionSendStatusQuery) =
+        dslContext.select(
+            SUBSCRIPTION.MEMBER_ID,
+            SUBSCRIPTION.TARGET_WORKBOOK_ID,
+            SUBSCRIPTION.SEND_TIME,
+            SUBSCRIPTION.SEND_DAY
+        )
+            .from(SUBSCRIPTION)
+            .where(SUBSCRIPTION.MEMBER_ID.eq(query.memberId))
+            .and(SUBSCRIPTION.DELETED_AT.isNull)
 }

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/command/InsertWorkbookSubscriptionCommand.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/command/InsertWorkbookSubscriptionCommand.kt
@@ -1,6 +1,11 @@
 package com.few.api.repo.dao.subscription.command
 
+import com.few.data.common.code.DayCode
+import java.time.LocalTime
+
 data class InsertWorkbookSubscriptionCommand(
     val workbookId: Long,
     val memberId: Long,
+    val sendDay: String? = DayCode.MON_TUE_WED_THU_FRI.code,
+    val sendTime: LocalTime? = LocalTime.of(8, 0),
 )

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectSubscriptionSendStatusQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/query/SelectSubscriptionSendStatusQuery.kt
@@ -1,0 +1,5 @@
+package com.few.api.repo.dao.subscription.query
+
+data class SelectSubscriptionSendStatusQuery(
+    val memberId: Long,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/SubscriptionSendStatus.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/subscription/record/SubscriptionSendStatus.kt
@@ -1,0 +1,10 @@
+package com.few.api.repo.dao.subscription.record
+
+import java.time.LocalTime
+
+data class SubscriptionSendStatus(
+    val memberId: Long,
+    val workbookId: Long,
+    val sendDay: String,
+    val sendTime: LocalTime,
+)


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #417 

💁‍♂️ PR 내용
----
- 멤버가 구독 전송 시간을 변경한 상태로 추가 구독하여도 기본 구독 전송 시간으로 생성되는 문제 해결

🙏 작업
----
[As-IS]
기존에는 멤버가 구독을 하면 기본 구독 전송 정보 (평일/8시)로 구독이 생성되었습니다.
[To-BE]
현재 구독하고 있는 학습지가 있다면 해당 학습지를 기준으로 구독이 생성될 수 있도록 수정하였습니다. 

🙈 PR 참고 사항
----
![스크린샷 2024-09-20 오후 4 38 12](https://github.com/user-attachments/assets/ff8fa4f1-70d6-468c-9210-4c89c9462adb)

현재 구독하고 있는 학습지가 있다면 해당 학습지를 기준으로 구독이 생성되는 모습

![스크린샷 2024-09-20 오후 4 39 24](https://github.com/user-attachments/assets/e83aafe0-59a3-47e4-a410-1845d65c1cc5)

현재 구독하고 있는 학습지가 없다면(삭제되었다면) 기본 구독 정보를 기준으로 구독이 생성되는 모습

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
