### PR TITLE
[Feat/#412] 이메일 OPEN, DELIVERY DELAY 이벤트 처리

### DIFF
--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/log/SendArticleEventHistoryDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/log/SendArticleEventHistoryDao.kt
@@ -1,0 +1,47 @@
+package com.few.api.repo.dao.log
+
+import com.few.api.repo.dao.log.command.InsertEventCommand
+import com.few.api.repo.dao.log.query.SelectEventByMessageIdAndEventTypeQuery
+import com.few.api.repo.dao.log.record.SendArticleEventHistoryRecord
+import jooq.jooq_dsl.tables.SendArticleEventHistory
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+
+@Repository
+class SendArticleEventHistoryDao(
+    private val dslContext: DSLContext,
+) {
+
+    fun insertEvent(command: InsertEventCommand) {
+        dslContext.insertInto(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY)
+            .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.MEMBER_ID, command.memberId)
+            .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.ARTICLE_ID, command.articleId)
+            .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.MESSAGE_ID, command.messageId)
+            .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.EVENT_TYPE_CD, command.eventType)
+            .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.SEND_TYPE_CD, command.sendType)
+    }
+
+    fun selectEventByMessageId(query: SelectEventByMessageIdAndEventTypeQuery): SendArticleEventHistoryRecord? {
+        return dslContext.select(
+            SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.MEMBER_ID.`as`(
+                SendArticleEventHistoryRecord::memberId.name
+            ),
+            SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.ARTICLE_ID.`as`(
+                SendArticleEventHistoryRecord::articleId.name
+            ),
+            SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.MESSAGE_ID.`as`(
+                SendArticleEventHistoryRecord::messageId.name
+            ),
+            SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.EVENT_TYPE_CD.`as`(
+                SendArticleEventHistoryRecord::eventType.name
+            ),
+            SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.SEND_TYPE_CD.`as`(
+                SendArticleEventHistoryRecord::sendType.name
+            )
+        )
+            .from(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY)
+            .where(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.MESSAGE_ID.eq(query.messageId))
+            .and(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.EVENT_TYPE_CD.eq(query.eventType))
+            .fetchOne()?.into(SendArticleEventHistoryRecord::class.java)
+    }
+}

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/log/SendArticleEventHistoryDao.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/log/SendArticleEventHistoryDao.kt
@@ -19,6 +19,7 @@ class SendArticleEventHistoryDao(
             .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.MESSAGE_ID, command.messageId)
             .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.EVENT_TYPE_CD, command.eventType)
             .set(SendArticleEventHistory.SEND_ARTICLE_EVENT_HISTORY.SEND_TYPE_CD, command.sendType)
+            .execute()
     }
 
     fun selectEventByMessageId(query: SelectEventByMessageIdAndEventTypeQuery): SendArticleEventHistoryRecord? {

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/log/command/InsertEventCommand.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/log/command/InsertEventCommand.kt
@@ -1,0 +1,9 @@
+package com.few.api.repo.dao.log.command
+
+data class InsertEventCommand(
+    val memberId: Long,
+    val articleId: Long,
+    val messageId: String,
+    val eventType: Byte,
+    val sendType: Byte,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/log/query/SelectEventByMessageIdAndEventTypeQuery.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/log/query/SelectEventByMessageIdAndEventTypeQuery.kt
@@ -1,0 +1,6 @@
+package com.few.api.repo.dao.log.query
+
+data class SelectEventByMessageIdAndEventTypeQuery(
+    val messageId: String,
+    val eventType: Byte,
+)

--- a/api-repo/src/main/kotlin/com/few/api/repo/dao/log/record/SendArticleEventHistoryRecord.kt
+++ b/api-repo/src/main/kotlin/com/few/api/repo/dao/log/record/SendArticleEventHistoryRecord.kt
@@ -1,0 +1,9 @@
+package com.few.api.repo.dao.log.record
+
+data class SendArticleEventHistoryRecord(
+    val memberId: Long,
+    val articleId: Long,
+    val messageId: String,
+    val eventType: Byte,
+    val sendType: Byte,
+)

--- a/api/src/main/kotlin/com/few/api/domain/article/service/ArticleLogService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/ArticleLogService.kt
@@ -1,0 +1,36 @@
+package com.few.api.domain.article.service
+
+import com.few.api.domain.article.service.dto.InsertOpenEventDto
+import com.few.api.domain.article.service.dto.SelectDeliveryEventByMessageIdDto
+import com.few.api.repo.dao.log.SendArticleEventHistoryDao
+import com.few.api.repo.dao.log.command.InsertEventCommand
+import com.few.api.repo.dao.log.query.SelectEventByMessageIdAndEventTypeQuery
+import com.few.api.repo.dao.log.record.SendArticleEventHistoryRecord
+import org.springframework.stereotype.Service
+
+@Service
+class ArticleLogService(
+    private val sendArticleEventHistoryDao: SendArticleEventHistoryDao,
+) {
+
+    fun selectDeliveryEventByMessageId(dto: SelectDeliveryEventByMessageIdDto): SendArticleEventHistoryRecord? {
+        return sendArticleEventHistoryDao.selectEventByMessageId(
+            SelectEventByMessageIdAndEventTypeQuery(
+                dto.messageId,
+                dto.eventType
+            )
+        )
+    }
+
+    fun insertOpenEvent(dto: InsertOpenEventDto) {
+        sendArticleEventHistoryDao.insertEvent(
+            InsertEventCommand(
+                memberId = dto.memberId,
+                articleId = dto.articleId,
+                messageId = dto.messageId,
+                eventType = dto.eventType,
+                sendType = dto.sendType
+            )
+        )
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/article/service/ArticleMemberService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/ArticleMemberService.kt
@@ -1,0 +1,18 @@
+package com.few.api.domain.article.service
+
+import com.few.api.domain.article.service.dto.ReadMemberByEmailDto
+import com.few.api.repo.dao.member.MemberDao
+import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
+import org.springframework.stereotype.Service
+
+@Service
+class ArticleMemberService(
+    private val memberDao: MemberDao,
+) {
+
+    fun readMemberByEmail(dto: ReadMemberByEmailDto): Long? {
+        return memberDao.selectMemberByEmail(
+            SelectMemberByEmailQuery(dto.email)
+        )?.memberId
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/article/service/dto/InsertOpenEventDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/dto/InsertOpenEventDto.kt
@@ -1,0 +1,9 @@
+package com.few.api.domain.article.service.dto
+
+data class InsertOpenEventDto(
+    val memberId: Long,
+    val articleId: Long,
+    val messageId: String,
+    val eventType: Byte,
+    val sendType: Byte,
+)

--- a/api/src/main/kotlin/com/few/api/domain/article/service/dto/ReadMemberByEmailDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/dto/ReadMemberByEmailDto.kt
@@ -1,0 +1,5 @@
+package com.few.api.domain.article.service.dto
+
+data class ReadMemberByEmailDto(
+    val email: String,
+)

--- a/api/src/main/kotlin/com/few/api/domain/article/service/dto/SelectDeliveryEventByMessageIdDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/service/dto/SelectDeliveryEventByMessageIdDto.kt
@@ -1,0 +1,6 @@
+package com.few.api.domain.article.service.dto
+
+data class SelectDeliveryEventByMessageIdDto(
+    val messageId: String,
+    val eventType: Byte,
+)

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticleByEmailUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/ReadArticleByEmailUseCase.kt
@@ -1,0 +1,45 @@
+package com.few.api.domain.article.usecase
+
+import com.few.api.domain.article.service.ArticleLogService
+import com.few.api.domain.article.service.ArticleMemberService
+import com.few.api.domain.article.service.dto.InsertOpenEventDto
+import com.few.api.domain.article.service.dto.ReadMemberByEmailDto
+import com.few.api.domain.article.service.dto.SelectDeliveryEventByMessageIdDto
+import com.few.api.domain.article.usecase.dto.ReadArticleByEmailUseCaseIn
+import com.few.api.web.support.EmailLogEventType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.webjars.NotFoundException
+
+@Component
+class ReadArticleByEmailUseCase(
+    private val memberService: ArticleMemberService,
+    private val articleLogService: ArticleLogService,
+) {
+
+    @Transactional
+    fun execute(useCaseIn: ReadArticleByEmailUseCaseIn) {
+        val memberId =
+            memberService.readMemberByEmail(ReadMemberByEmailDto(useCaseIn.destination[0]))
+                ?: throw NotFoundException("member.notfound.email")
+
+        val record =
+            articleLogService.selectDeliveryEventByMessageId(
+                SelectDeliveryEventByMessageIdDto(
+                    useCaseIn.messageId,
+                    EmailLogEventType.DELIVERY.code
+                )
+            )
+                ?: throw IllegalStateException("event is not found")
+
+        articleLogService.insertOpenEvent(
+            InsertOpenEventDto(
+                memberId = memberId,
+                articleId = record.articleId,
+                messageId = record.messageId,
+                eventType = EmailLogEventType.OPEN.code,
+                sendType = record.sendType
+            )
+        )
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleByEmailUseCaseIn.kt
+++ b/api/src/main/kotlin/com/few/api/domain/article/usecase/dto/ReadArticleByEmailUseCaseIn.kt
@@ -1,0 +1,11 @@
+package com.few.api.domain.article.usecase.dto
+
+import com.few.api.web.support.EmailLogEventType
+import com.few.api.web.support.SendType
+
+data class ReadArticleByEmailUseCaseIn(
+    val messageId: String,
+    val destination: List<String>,
+    val eventType: EmailLogEventType,
+    val sendType: SendType,
+)

--- a/api/src/main/kotlin/com/few/api/domain/log/AddEmailLogUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/log/AddEmailLogUseCase.kt
@@ -36,7 +36,7 @@ class AddEmailLogUseCase(
                 memberId = memberId,
                 articleId = record.articleId,
                 messageId = record.messageId,
-                eventType = record.eventType,
+                eventType = useCaseIn.eventType.code,
                 sendType = record.sendType
             )
         ).let {

--- a/api/src/main/kotlin/com/few/api/domain/log/AddEmailLogUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/log/AddEmailLogUseCase.kt
@@ -1,0 +1,53 @@
+package com.few.api.domain.log
+
+import com.few.api.domain.log.dto.AddEmailLogUseCaseIn
+import com.few.api.repo.dao.log.SendArticleEventHistoryDao
+import com.few.api.repo.dao.log.command.InsertEventCommand
+import com.few.api.repo.dao.log.query.SelectEventByMessageIdAndEventTypeQuery
+import com.few.api.repo.dao.member.MemberDao
+import com.few.api.repo.dao.member.query.SelectMemberByEmailQuery
+import com.few.api.web.support.EmailLogEventType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.webjars.NotFoundException
+
+@Component
+class AddEmailLogUseCase(
+    private val memberDao: MemberDao,
+    private val sendArticleEventHistoryDao: SendArticleEventHistoryDao,
+) {
+    @Transactional
+    fun execute(useCaseIn: AddEmailLogUseCaseIn) {
+        val (memberId, _, _, _) = memberDao.selectMemberByEmail(
+            SelectMemberByEmailQuery(useCaseIn.destination[0])
+        ) ?: throw NotFoundException("member.notfound.email")
+
+        val record =
+            sendArticleEventHistoryDao.selectEventByMessageId(
+                SelectEventByMessageIdAndEventTypeQuery(
+                    useCaseIn.messageId,
+                    EmailLogEventType.SEND.code
+                )
+            )
+                ?: throw IllegalStateException("event is not found")
+
+        sendArticleEventHistoryDao.insertEvent(
+            InsertEventCommand(
+                memberId = memberId,
+                articleId = record.articleId,
+                messageId = record.messageId,
+                eventType = record.eventType,
+                sendType = record.sendType
+            )
+        ).let {
+            when (EmailLogEventType.fromCode(record.eventType)) {
+                EmailLogEventType.DELIVERYDELAY -> {
+                    TODO("배송지연 이벤트 발생시 처리 로직 추가")
+                }
+                else -> {
+                    TODO("다른 이벤트는 필요시 추가한다.")
+                }
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/log/AddEmailLogUseCase.kt
+++ b/api/src/main/kotlin/com/few/api/domain/log/AddEmailLogUseCase.kt
@@ -40,14 +40,7 @@ class AddEmailLogUseCase(
                 sendType = record.sendType
             )
         ).let {
-            when (EmailLogEventType.fromCode(record.eventType)) {
-                EmailLogEventType.DELIVERYDELAY -> {
-                    TODO("배송지연 이벤트 발생시 처리 로직 추가")
-                }
-                else -> {
-                    TODO("다른 이벤트는 필요시 추가한다.")
-                }
-            }
+//            TODO("다른 이벤트는 필요시 추가한다.")
         }
     }
 }

--- a/api/src/main/kotlin/com/few/api/domain/log/dto/AddEmailLogUseCaseIn.kt
+++ b/api/src/main/kotlin/com/few/api/domain/log/dto/AddEmailLogUseCaseIn.kt
@@ -1,0 +1,11 @@
+package com.few.api.domain.log.dto
+
+import com.few.api.web.support.EmailLogEventType
+import java.time.LocalDateTime
+
+data class AddEmailLogUseCaseIn(
+    val eventType: EmailLogEventType,
+    val messageId: String,
+    val destination: List<String>,
+    val mailTimestamp: LocalDateTime,
+)

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionEmailService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionEmailService.kt
@@ -15,8 +15,8 @@ class SubscriptionEmailService(
         private const val ARTICLE_TEMPLATE = "article"
     }
 
-    fun sendArticleEmail(dto: SendArticleInDto) {
-        sendArticleEmailService.send(
+    fun sendArticleEmail(dto: SendArticleInDto): String {
+        return sendArticleEmailService.send(
             SendArticleEmailArgs(
                 dto.toEmail,
                 ARTICLE_SUBJECT_TEMPLATE.format(

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionLogService.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/SubscriptionLogService.kt
@@ -1,0 +1,25 @@
+package com.few.api.domain.subscription.service
+
+import com.few.api.domain.subscription.service.dto.InsertSendEventDto
+import com.few.api.repo.dao.log.SendArticleEventHistoryDao
+import com.few.api.repo.dao.log.command.InsertEventCommand
+import com.few.api.web.support.EmailLogEventType
+import org.springframework.stereotype.Service
+
+@Service
+class SubscriptionLogService(
+    private val sendArticleEventHistoryDao: SendArticleEventHistoryDao,
+) {
+
+    fun insertSendEvent(dto: InsertSendEventDto) {
+        sendArticleEventHistoryDao.insertEvent(
+            InsertEventCommand(
+                memberId = dto.memberId,
+                articleId = dto.articleId,
+                messageId = dto.messageId,
+                eventType = EmailLogEventType.SEND.code,
+                sendType = dto.sendType
+            )
+        )
+    }
+}

--- a/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/InsertSendEventDto.kt
+++ b/api/src/main/kotlin/com/few/api/domain/subscription/service/dto/InsertSendEventDto.kt
@@ -1,0 +1,8 @@
+package com.few.api.domain.subscription.service.dto
+
+data class InsertSendEventDto(
+    val memberId: Long,
+    val articleId: Long,
+    val messageId: String,
+    val sendType: Byte,
+)

--- a/api/src/main/kotlin/com/few/api/security/config/WebSecurityConfig.kt
+++ b/api/src/main/kotlin/com/few/api/security/config/WebSecurityConfig.kt
@@ -144,6 +144,7 @@ class WebSecurityConfig(
 
                     /** 어드민 */
                     AntPathRequestMatcher("/api/v1/admin/**", HttpMethod.POST.name()),
+                    AntPathRequestMatcher("/api/v1/articles/views", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/api/v1/logs", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/batch/**"),
 
@@ -188,6 +189,7 @@ class WebSecurityConfig(
 
                     /** 어드민 */
                     AntPathRequestMatcher("/api/v1/admin/**", HttpMethod.POST.name()),
+                    AntPathRequestMatcher("/api/v1/articles/views", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/api/v1/logs", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/batch/**"),
 

--- a/api/src/main/kotlin/com/few/api/security/config/WebSecurityConfig.kt
+++ b/api/src/main/kotlin/com/few/api/security/config/WebSecurityConfig.kt
@@ -146,6 +146,7 @@ class WebSecurityConfig(
                     AntPathRequestMatcher("/api/v1/admin/**", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/api/v1/articles/views", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/api/v1/logs", HttpMethod.POST.name()),
+                    AntPathRequestMatcher("/api/v1/logs/email/articles", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/batch/**"),
 
                     /** 인증 불필요 */
@@ -190,6 +191,7 @@ class WebSecurityConfig(
                     /** 어드민 */
                     AntPathRequestMatcher("/api/v1/admin/**", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/api/v1/articles/views", HttpMethod.POST.name()),
+                    AntPathRequestMatcher("/api/v1/logs/email/articles", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/api/v1/logs", HttpMethod.POST.name()),
                     AntPathRequestMatcher("/batch/**"),
 

--- a/api/src/main/kotlin/com/few/api/web/config/WebConfig.kt
+++ b/api/src/main/kotlin/com/few/api/web/config/WebConfig.kt
@@ -1,8 +1,6 @@
 package com.few.api.web.config
 
-import com.few.api.web.config.converter.DayCodeConverter
-import com.few.api.web.config.converter.ViewConverter
-import com.few.api.web.config.converter.WorkBookCategoryConverter
+import com.few.api.web.config.converter.*
 import com.few.api.web.support.method.UserArgumentHandlerMethodArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.FormatterRegistry
@@ -34,6 +32,8 @@ class WebConfig(
         registry.addConverter(WorkBookCategoryConverter())
         registry.addConverter(ViewConverter())
         registry.addConverter(DayCodeConverter())
+        registry.addConverter(EmailLogEventTypeConverter())
+        registry.addConverter(SendTypeConverter())
     }
 
     override fun addArgumentResolvers(argumentResolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/api/src/main/kotlin/com/few/api/web/config/converter/EmailLogEventTypeConverter.kt
+++ b/api/src/main/kotlin/com/few/api/web/config/converter/EmailLogEventTypeConverter.kt
@@ -1,0 +1,11 @@
+package com.few.api.web.config.converter
+
+import com.few.api.web.support.EmailLogEventType
+import org.springframework.core.convert.converter.Converter
+
+class EmailLogEventTypeConverter : Converter<String, EmailLogEventType> {
+    override fun convert(source: String): EmailLogEventType {
+        return EmailLogEventType.fromType(source)
+            ?: throw IllegalArgumentException("EmailLogEventType not found. type=$source")
+    }
+}

--- a/api/src/main/kotlin/com/few/api/web/config/converter/SendTypeConverter.kt
+++ b/api/src/main/kotlin/com/few/api/web/config/converter/SendTypeConverter.kt
@@ -1,0 +1,10 @@
+package com.few.api.web.config.converter
+
+import com.few.api.web.support.SendType
+import org.springframework.core.convert.converter.Converter
+
+class SendTypeConverter : Converter<Byte, SendType> {
+    override fun convert(source: Byte): SendType {
+        return SendType.fromCode(source)
+    }
+}

--- a/api/src/main/kotlin/com/few/api/web/config/converter/SendTypeConverter.kt
+++ b/api/src/main/kotlin/com/few/api/web/config/converter/SendTypeConverter.kt
@@ -3,8 +3,8 @@ package com.few.api.web.config.converter
 import com.few.api.web.support.SendType
 import org.springframework.core.convert.converter.Converter
 
-class SendTypeConverter : Converter<Byte, SendType> {
-    override fun convert(source: Byte): SendType {
-        return SendType.fromCode(source)
+class SendTypeConverter : Converter<String, SendType> {
+    override fun convert(source: String): SendType {
+        return SendType.fromCode(source.toByte())
     }
 }

--- a/api/src/main/kotlin/com/few/api/web/controller/admin/ApiLogController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/admin/ApiLogController.kt
@@ -1,7 +1,9 @@
 package com.few.api.web.controller.admin
 
 import com.few.api.domain.log.AddApiLogUseCase
+import com.few.api.domain.log.AddEmailLogUseCase
 import com.few.api.domain.log.dto.AddApiLogUseCaseIn
+import com.few.api.domain.log.dto.AddEmailLogUseCaseIn
 import com.few.api.web.controller.admin.request.*
 import com.few.api.web.support.ApiResponse
 import com.few.api.web.support.ApiResponseGenerator
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(value = ["/api/v1/logs"])
 class ApiLogController(
     private val addApiLogUseCase: AddApiLogUseCase,
+    private val addEmailLogUseCase: AddEmailLogUseCase,
 ) {
     @PostMapping
     fun addApiLog(@RequestBody request: ApiLogRequest): ApiResponse<ApiResponse.Success> {
@@ -24,6 +27,19 @@ class ApiLogController(
             addApiLogUseCase.execute(it)
         }
 
+        return ApiResponseGenerator.success(HttpStatus.OK)
+    }
+
+    @PostMapping("/email/articles")
+    fun addEmailLog(@RequestBody request: EmailLogRequest): ApiResponse<ApiResponse.Success> {
+        AddEmailLogUseCaseIn(
+            eventType = request.eventType,
+            messageId = request.messageId,
+            destination = request.destination,
+            mailTimestamp = request.mailTimestamp
+        ).let {
+            addEmailLogUseCase.execute(it)
+        }
         return ApiResponseGenerator.success(HttpStatus.OK)
     }
 }

--- a/api/src/main/kotlin/com/few/api/web/controller/admin/ApiLogController.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/admin/ApiLogController.kt
@@ -7,6 +7,7 @@ import com.few.api.domain.log.dto.AddEmailLogUseCaseIn
 import com.few.api.web.controller.admin.request.*
 import com.few.api.web.support.ApiResponse
 import com.few.api.web.support.ApiResponseGenerator
+import com.few.api.web.support.EmailLogEventType
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
@@ -33,7 +34,8 @@ class ApiLogController(
     @PostMapping("/email/articles")
     fun addEmailLog(@RequestBody request: EmailLogRequest): ApiResponse<ApiResponse.Success> {
         AddEmailLogUseCaseIn(
-            eventType = request.eventType,
+            eventType = EmailLogEventType.fromType(request.eventType)
+                ?: throw IllegalArgumentException("EmailLogEventType not found. type=${request.eventType}"),
             messageId = request.messageId,
             destination = request.destination,
             mailTimestamp = request.mailTimestamp

--- a/api/src/main/kotlin/com/few/api/web/controller/admin/request/EmailLogRequest.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/admin/request/EmailLogRequest.kt
@@ -1,0 +1,13 @@
+package com.few.api.web.controller.admin.request
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.few.api.web.support.EmailLogEventType
+import java.time.LocalDateTime
+
+data class EmailLogRequest(
+    val eventType: EmailLogEventType,
+    val messageId: String,
+    val destination: List<String>,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val mailTimestamp: LocalDateTime,
+)

--- a/api/src/main/kotlin/com/few/api/web/controller/admin/request/EmailLogRequest.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/admin/request/EmailLogRequest.kt
@@ -1,11 +1,10 @@
 package com.few.api.web.controller.admin.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.few.api.web.support.EmailLogEventType
 import java.time.LocalDateTime
 
 data class EmailLogRequest(
-    val eventType: EmailLogEventType,
+    val eventType: String,
     val messageId: String,
     val destination: List<String>,
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")

--- a/api/src/main/kotlin/com/few/api/web/controller/article/request/ReadArticleByEmailRequest.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/request/ReadArticleByEmailRequest.kt
@@ -1,13 +1,6 @@
 package com.few.api.web.controller.article.request
 
-import com.fasterxml.jackson.annotation.JsonFormat
-import com.few.api.web.support.EmailLogEventType
-import java.time.LocalDateTime
-
 data class ReadArticleByEmailRequest(
-    val eventType: EmailLogEventType,
     val messageId: String,
     val destination: List<String>,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    val mailTimestamp: LocalDateTime,
 )

--- a/api/src/main/kotlin/com/few/api/web/controller/article/request/ReadArticleByEmailRequest.kt
+++ b/api/src/main/kotlin/com/few/api/web/controller/article/request/ReadArticleByEmailRequest.kt
@@ -1,0 +1,13 @@
+package com.few.api.web.controller.article.request
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.few.api.web.support.EmailLogEventType
+import java.time.LocalDateTime
+
+data class ReadArticleByEmailRequest(
+    val eventType: EmailLogEventType,
+    val messageId: String,
+    val destination: List<String>,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val mailTimestamp: LocalDateTime,
+)

--- a/api/src/main/kotlin/com/few/api/web/support/EmailLogEventType.kt
+++ b/api/src/main/kotlin/com/few/api/web/support/EmailLogEventType.kt
@@ -1,0 +1,23 @@
+package com.few.api.web.support
+
+/**
+ * @see com.few.data.common.code.SendEventType
+ */
+enum class EmailLogEventType(val code: Byte, val type: String) {
+    OPEN(0, "open"),
+    DELIVERY(1, "delivery"),
+    CLICK(2, "click"),
+    SEND(3, "send"),
+    DELIVERYDELAY(4, "deliverydelay"),
+    ;
+
+    companion object {
+        fun fromType(type: String): EmailLogEventType? {
+            return entries.find { it.type == type }
+        }
+
+        fun fromCode(code: Byte): EmailLogEventType? {
+            return entries.find { it.code == code }
+        }
+    }
+}

--- a/api/src/main/kotlin/com/few/api/web/support/EmailLogEventType.kt
+++ b/api/src/main/kotlin/com/few/api/web/support/EmailLogEventType.kt
@@ -13,7 +13,7 @@ enum class EmailLogEventType(val code: Byte, val type: String) {
 
     companion object {
         fun fromType(type: String): EmailLogEventType? {
-            return entries.find { it.type == type }
+            return entries.find { it.type == type.lowercase() }
         }
 
         fun fromCode(code: Byte): EmailLogEventType? {

--- a/api/src/main/kotlin/com/few/api/web/support/SendType.kt
+++ b/api/src/main/kotlin/com/few/api/web/support/SendType.kt
@@ -1,0 +1,16 @@
+package com.few.api.web.support
+
+/**
+ * @see com.few.data.common.code.SendType
+ */
+enum class SendType(val code: Byte) {
+    EMAIL(0),
+    AWSSES(1),
+    ;
+
+    companion object {
+        fun fromCode(code: Byte): SendType {
+            return entries.first { it.code == code }
+        }
+    }
+}

--- a/batch/src/main/kotlin/com/few/batch/data/common/code/BatchSendEventType.kt
+++ b/batch/src/main/kotlin/com/few/batch/data/common/code/BatchSendEventType.kt
@@ -1,0 +1,24 @@
+package com.few.batch.data.common.code
+
+/**
+ * @see com.few.data.common.code.SendEventType
+ */
+enum class BatchSendEventType(val code: Byte, val type: String) {
+
+    OPEN(0, "open"),
+    DELIVERY(1, "delivery"),
+    CLICK(2, "click"),
+    SEND(3, "send"),
+    DELIVERYDELAY(4, "deliverydelay"),
+    ;
+
+    companion object {
+        fun fromType(type: String): BatchSendEventType? {
+            return entries.find { it.type == type }
+        }
+
+        fun fromCode(code: Byte): BatchSendEventType? {
+            return entries.find { it.code == code }
+        }
+    }
+}

--- a/batch/src/main/kotlin/com/few/batch/data/common/code/BatchSendType.kt
+++ b/batch/src/main/kotlin/com/few/batch/data/common/code/BatchSendType.kt
@@ -1,0 +1,9 @@
+package com.few.batch.data.common.code
+
+/**
+ * @see com.few.data.common.code.SendType
+ */
+enum class BatchSendType(val code: Byte) {
+    EMAIL(0),
+    AWSSES(1),
+}

--- a/batch/src/main/kotlin/com/few/batch/service/article/writer/support/MailServiceArgsGenerator.kt
+++ b/batch/src/main/kotlin/com/few/batch/service/article/writer/support/MailServiceArgsGenerator.kt
@@ -13,6 +13,7 @@ import java.time.LocalDate
 data class MailServiceArg(
     val memberId: Long,
     val workbookId: Long,
+    val articleId: Long,
     val sendArticleEmailArgs: SendArticleEmailArgs,
 )
 
@@ -53,7 +54,8 @@ class MailServiceArgsGenerator(
 
             MailServiceArg(
                 it.memberId,
-                it.targetWorkBookId,
+                memberArticle.workbookId,
+                memberArticle.articleId,
                 SendArticleEmailArgs(
                     toEmail,
                     ARTICLE_SUBJECT_TEMPLATE.format(

--- a/data/db/migration/entity/V1.00.0.25__add_send_article_event_history_table.sql
+++ b/data/db/migration/entity/V1.00.0.25__add_send_article_event_history_table.sql
@@ -1,0 +1,12 @@
+-- 전송 아티클 이벤트 히스토리 테이블
+CREATE TABLE SEND_ARTICLE_EVENT_HISTORY
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id   BIGINT       NOT NULL,
+    article_id  BIGINT       NOT NULL,
+    message_id   VARCHAR(255) NOT NULL,
+    event_type_cd TINYINT      NOT NULL,
+    send_type_cd TINYINT      NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);

--- a/data/src/main/kotlin/com/few/data/common/code/SendEventType.kt
+++ b/data/src/main/kotlin/com/few/data/common/code/SendEventType.kt
@@ -1,0 +1,24 @@
+package com.few.data.common.code
+
+/**
+ * @see com.few.api.web.support.EmailLogEventType
+ * @see com.few.batch.data.common.code.BatchSendEventType
+ */
+enum class SendEventType(val code: Byte, val type: String) {
+    OPEN(0, "open"),
+    DELIVERY(1, "delivery"),
+    CLICK(2, "click"),
+    SEND(3, "send"),
+    DELIVERYDELAY(4, "deliverydelay"),
+    ;
+
+    companion object {
+        fun fromType(type: String): SendEventType? {
+            return entries.find { it.type == type }
+        }
+
+        fun fromCode(code: Byte): SendEventType? {
+            return entries.find { it.code == code }
+        }
+    }
+}

--- a/data/src/main/kotlin/com/few/data/common/code/SendType.kt
+++ b/data/src/main/kotlin/com/few/data/common/code/SendType.kt
@@ -1,0 +1,10 @@
+package com.few.data.common.code
+
+/**
+ * @see com.few.api.web.support.SendType
+ * @see com.few.batch.data.common.code.BatchSendType
+ */
+enum class SendType(val code: Byte) {
+    EMAIL(0),
+    AWSSES(1),
+}


### PR DESCRIPTION
🎫 연관 이슈
---
resolved: #412 

💁‍♂️ PR 내용
----
- 이메일 OPEN, DELIVERY DELAY 이벤트 처리

🙏 작업
----
- 이메일 DELIVERY, SEND 이벤트는 단순히 기록만 합니다.
- 이메일 DELIVERYDELAY 이벤트는 현재는 단순히 기록만 하지만 추후 관련된 처리 할 예정 (ex 기록후 해당 멤버는 ses가 아닌 java email로 전송)
- 이메일 OPEN 이벤트는 send_article_event_history에만 누적중
    - @hun-ca article_view_his에도 누적하는게 좋을까요..? 총 뷰 계산할때 뷰 테이블이 분산되면 문제가 될 수 있지 않을까 해서요..?!

🙈 PR 참고 사항
----

📸 스크린샷
----
<img width="1728" alt="스크린샷 2024-09-21 오전 12 41 56" src="https://github.com/user-attachments/assets/8dacbce7-17d3-41b9-9552-95de2121b31c">

다른 것은 기존 로그 컨트롤러와 동일해서 OPEN 이벤트만 확인하였습니다.

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
